### PR TITLE
Move Element to Flatpak / Homebrew

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,6 +130,21 @@
         "type": "github"
       }
     },
+    "nix-flatpak": {
+      "locked": {
+        "lastModified": 1702756026,
+        "narHash": "sha256-KEYa3S0JZCR2WpbEnVn9EXmN5/oCgWGlGg9yHoz5MLc=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "4f39230e34e8d5056e5b58ed9e4bb264438090bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
     "nix-homebrew": {
       "inputs": {
         "brew-src": "brew-src",
@@ -234,6 +249,7 @@
         "genebean-omp-themes": "genebean-omp-themes",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
+        "nix-flatpak": "nix-flatpak",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,9 @@
     # Manage Homebrew itself
     nix-homebrew.url = "github:zhaofengli-wip/nix-homebrew";
 
+    # Manage flatpaks
+    nix-flatpak.url = "github:gmodena/nix-flatpak"; # unstable branch. Use github:gmodena/nix-flatpak/?ref=<tag> to pin releases.
+
     # Format disks with nix-config
     disko = {
       url = "github:nix-community/disko";
@@ -40,7 +43,7 @@
     };
 
   }; # end inputs
-  outputs = inputs@{ self, nixpkgs, nixpkgs-unstable, nix-darwin, home-manager, nix-homebrew, disko, sops-nix, genebean-omp-themes, ... }: let
+  outputs = inputs@{ self, nixpkgs, nixpkgs-unstable, nix-darwin, home-manager, nix-homebrew, nix-flatpak, disko, sops-nix, genebean-omp-themes, ... }: let
 
     # creates a macOS system config
     darwinHostConfig = system: hostname: username: nix-darwin.lib.darwinSystem {
@@ -99,6 +102,8 @@
             ];
           };
         }
+
+        nix-flatpak.nixosModules.nix-flatpak
 
         sops-nix.nixosModules.sops # system wide secrets management
         ./modules/system/common/all-nixos.nix # system-wide stuff

--- a/modules/home-manager/common/all-gui.nix
+++ b/modules/home-manager/common/all-gui.nix
@@ -1,6 +1,6 @@
 { pkgs, genebean-omp-themes, ... }: {
   home.packages = with pkgs; [
-    element-desktop
+    # nothing here right now
   ];
   programs = {
     vscode = {

--- a/modules/system/common/all-darwin.nix
+++ b/modules/system/common/all-darwin.nix
@@ -40,6 +40,7 @@
       "angry-ip-scanner"
       "audacity"
       "balenaetcher"
+      "element"
       "firefox"
       "font-hack-nerd-font"
       "font-inconsolata-g-for-powerline"

--- a/modules/system/common/all-nixos.nix
+++ b/modules/system/common/all-nixos.nix
@@ -49,6 +49,16 @@
   security.sudo.wheelNeedsPassword = false;
 
   services = {
+    flatpak = {
+      enable = true;
+      packages = [
+        "im.riot.Riot"
+      ];
+      update.auto = {
+        enable = true;
+        onCalendar = "daily";
+      };
+    };
     openssh.enable = true;
     tailscale = {
       enable = true;


### PR DESCRIPTION
Element seems to need to compile electron every single update and, on macOS, runs another app called electron that is not of use to me. Flatpak and Homebrew will work faster and be user friendly all around.