### PR TITLE
Adjust theme a little, add alias nve

### DIFF
--- a/modules/home-manager/common/all-cli.nix
+++ b/modules/home-manager/common/all-cli.nix
@@ -290,6 +290,7 @@ in {
         gpge = "gpg2 --encrypt --sign --armor -r ";
         hubpr = "hub pull-request --push --browse";
         nvd = "NVIM_APPNAME=nvim-dots nvim";
+        nve = "nvd ~/repos/dots/modules/home-manager/files/nvim/lua";
         pssh = "ssh -o 'UserKnownHostsFile /dev/null' -o 'StrictHostKeyChecking no' -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa -o KexAlgorithms=+diffie-hellman-group1-sha1 -i ~/.ssh/id_rsa-acceptance";
         sal = "ssh-add -L";
         st = "open -a SourceTree";

--- a/modules/home-manager/files/nvim/lua/plugins/catppuccin.lua
+++ b/modules/home-manager/files/nvim/lua/plugins/catppuccin.lua
@@ -5,6 +5,51 @@ return {
   lazy = false,
   priority = 1000,
   config = function()
+    require("catppuccin").setup({
+      color_overrides = {
+        frappe = {
+          base = "#07042B",
+          mantle = "#0c0746",
+          crust = "#10095d",
+          rosewater = "#FF7F7F", -- used for cursor
+        },
+      },
+      custom_highlights = function(colors)
+        return {
+          Comment = { fg = colors.subtext0 },
+        }
+      end,
+    })
     vim.cmd.colorscheme("catppuccin")
   end,
+
+  --[[
+  -- original palette from frappe:
+	rosewater = "#f2d5cf",
+	flamingo = "#eebebe",
+	pink = "#f4b8e4",
+	mauve = "#ca9ee6",
+	red = "#e78284",
+	maroon = "#ea999c",
+	peach = "#ef9f76",
+	yellow = "#e5c890",
+	green = "#a6d189",
+	teal = "#81c8be",
+	sky = "#99d1db",
+	sapphire = "#85c1dc",
+	blue = "#8caaee",
+	lavender = "#babbf1",
+	text = "#c6d0f5",
+	subtext1 = "#b5bfe2",
+	subtext0 = "#a5adce",
+	overlay2 = "#949cbb",
+	overlay1 = "#838ba7",
+	overlay0 = "#737994",
+	surface2 = "#626880",
+	surface1 = "#51576d",
+	surface0 = "#414559",
+	base = "#303446",
+	mantle = "#292c3c",
+	crust = "#232634",
+  --]]
 }


### PR DESCRIPTION
nve stands for nvim edit and utilized the nvd alias to open my vim
config in a way that I can see changes prior to running nix. The nvd
alias is short for nvim dots and is just a shortcut to opening the
configs within my  dots repo and having that nvim session use those
configs directly instead of the configs in the default location.