### PR TITLE
Updates, nvd, fastfetch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1694443293,
-        "narHash": "sha256-wBjbF2RRFyD4lN7ie98VnggmNBwAPv/dg2U+w5mUyuM=",
+        "lastModified": 1705326576,
+        "narHash": "sha256-9PvMgHgdbpb5vBO8fHCRufodR731ynzGMF9+68vKWck=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "4afb8e5602f3ecc9edf67a44257d8eceeaa8a108",
+        "rev": "1c612baa096c69f2fcb221c74e6f5b9979efdcee",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.1.11",
+        "ref": "4.2.4",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703532766,
-        "narHash": "sha256-ojjW3cuNmqL5uqDWohwLoO8dYpheM5+AfgsNmGIMwG8=",
+        "lastModified": 1706261939,
+        "narHash": "sha256-KQ3Hb3XVSrxOLfiY2D63QD5+LsLwFeY81ZScD4GRp0o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "1b191113874dee97796749bb21eac3d84735c70a",
+        "rev": "c12719812dde4dcbc4119a2b09766a51c9c498d5",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703367386,
-        "narHash": "sha256-FMbm48UGrBfOWGt8+opuS+uLBLQlRfhiYXhHNcYMS5k=",
+        "lastModified": 1705659542,
+        "narHash": "sha256-WA3xVfAk1AYmFdwghT7mt/erYpsU6JPu9mdTEP/e9HQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5824a76bc6bb93d1dce9ebbbcb09a9b6abcc224",
+        "rev": "10cd9c53115061aa6a0a90aad0b0dde6a999cdb9",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703415240,
-        "narHash": "sha256-SgsAYwDo2wWHUdZeNKKRRT402sRzQ/rLmzxH/wqMUPw=",
+        "lastModified": 1705915768,
+        "narHash": "sha256-+Jlz8OAqkOwJlioac9wtpsCnjgGYUhvLpgJR/5tP9po=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "f454cff5fe84adca9e8aa8d546d2c9879b789950",
+        "rev": "1e706ef323de76236eb183d7784f3bd57255ec0b",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1702756026,
-        "narHash": "sha256-KEYa3S0JZCR2WpbEnVn9EXmN5/oCgWGlGg9yHoz5MLc=",
+        "lastModified": 1706131725,
+        "narHash": "sha256-HK/maOUUo+4tKL06VSV5szJXTtc7QqcO9F5c0FGi2F8=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "4f39230e34e8d5056e5b58ed9e4bb264438090bd",
+        "rev": "dfa162fab581ba293f5faa866e91c553b78a01aa",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1695057498,
-        "narHash": "sha256-wn3j7u5tOgLLbNxZC542rJiP5iX323m+CoGPMgPOxp4=",
+        "lastModified": 1705952034,
+        "narHash": "sha256-H0nk8Gk8kPw4yi2WwOTsSHgPrzSwyNgWEYHk10IJwfc=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "6ab33c5e9249e74401144a7c667d96a757c5d341",
+        "rev": "40f5ee46b58e7c5f1927e2c5a583dc3d7e571ed9",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703351344,
-        "narHash": "sha256-9FEelzftkE9UaJ5nqxidaJJPEhe9TPhbypLHmc2Mysc=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7790e078f8979a9fcd543f9a47427eeaba38f268",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -197,11 +197,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1703499205,
-        "narHash": "sha256-lF9rK5mSUfIZJgZxC3ge40tp1gmyyOXZ+lRY3P8bfbg=",
+        "lastModified": 1706173671,
+        "narHash": "sha256-lciR7kQUK2FCAYuszyd7zyRRmTaXVeoZsCyK6QFpGdk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e1fa12d4f6c6fe19ccb59cac54b5b3f25e160870",
+        "rev": "4fddc9be4eaf195d631333908f2a454b03628ee5",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1703588687,
-        "narHash": "sha256-yj/AFxJjW/aE0lmHz1wlTk3jScZqVjQQEeBOnhyroRc=",
+        "lastModified": 1706287586,
+        "narHash": "sha256-Hf3QdV2ZeI9MgDNGY3dulFXIU3G+OKp5hL71gQb/nQA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad9ca03be8aaf8d6e458102e7d77370b7fe71ccf",
+        "rev": "205d4e308a7257e3004e384ac9006f1df003a95e",
         "type": "github"
       },
       "original": {
@@ -264,11 +264,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703387502,
-        "narHash": "sha256-JnWuQmyanPtF8c5yAEFXVWzaIlMxA3EAZCh8XNvnVqE=",
+        "lastModified": 1706130372,
+        "narHash": "sha256-fHZxKH1DhsXPP36a2vJ91Zy6S+q6+QRIFlpLr9fZHU8=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "e523e89763ff45f0a6cf15bcb1092636b1da9ed3",
+        "rev": "4606d9b1595e42ffd9b75b9e69667708c70b1d68",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/common/all-cli.nix
+++ b/modules/home-manager/common/all-cli.nix
@@ -16,6 +16,7 @@ in {
     du-dust
     duf
     esptool
+    fastfetch
     fd
     git-filter-repo
     glab
@@ -34,6 +35,7 @@ in {
     nodejs
     nodePackages.npm
     nurl
+    nvd
     powershell
     puppet-lint
     rename
@@ -300,8 +302,8 @@ in {
         gitextract = "git log --pretty=email --patch-with-stat --reverse --full-index --binary --";
         gpge = "gpg2 --encrypt --sign --armor -r ";
         hubpr = "hub pull-request --push --browse";
-        nvd = "NVIM_APPNAME=nvim-dots nvim";
-        nve = "nvd ~/repos/dots/modules/home-manager/files/nvim/lua";
+        nvdots = "NVIM_APPNAME=nvim-dots nvim";
+        nve = "nvdots ~/repos/dots/modules/home-manager/files/nvim/lua";
         pssh = "ssh -o 'UserKnownHostsFile /dev/null' -o 'StrictHostKeyChecking no' -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa -o KexAlgorithms=+diffie-hellman-group1-sha1 -i ~/.ssh/id_rsa-acceptance";
         sal = "ssh-add -L";
         st = "open -a SourceTree";


### PR DESCRIPTION
```bash
╔ ☕  rainbow-planet ~/repos/dots on   updates ≢
╚ᐅ nvd diff /nix/var/nix/profiles/system-{138,141}-link
<<< /nix/var/nix/profiles/system-138-link
>>> /nix/var/nix/profiles/system-141-link
Version changes:
[U.]  #01  breeze-icons                 5.112.0 -> 5.113.0
[U*]  #02  cpupower                     6.1.69 -> 6.1.74
[U.]  #03  dns-root-data                2019-01-11 x2 -> 2023-11-27 x2
[U*]  #04  epiphany                     45.1 -> 45.2
[U.]  #05  evolution-data-server        3.50.2 x2 -> 3.50.3 x2
[U*]  #06  firefox                      121.0 -> 122.0
[U.]  #07  firefox-unwrapped            121.0 -> 122.0
[U.]  #08  folks                        0.15.6 -> 0.15.7
[U.]  #09  freerdp                      2.11.2 -> 2.11.5
[U.]  #10  fzf                          0.44.1, 0.44.1-man -> 0.45.0, 0.45.0-man
[U.]  #11  gh                           2.39.1 -> 2.39.2
[U.]  #12  gjs                          1.78.0 -> 1.78.1
[U*]  #13  glib                         2.78.1 x2, 2.78.1-bin, 2.78.1-dev -> 2.78.3 x2, 2.78.3-bin, 2.78.3-dev
[U*]  #14  gnome-maps                   45.2 -> 45.3
[U*]  #15  gnome-settings-daemon        45.0 -> 45.1
[U*]  #16  gnome-shell                  45.2 -> 45.3
[U*]  #17  gnome-software               45.2 -> 45.3
[U.]  #18  gst-devtools                 1.22.7 -> 1.22.8
[U.]  #19  gst-editing-services         1.22.7 -> 1.22.8
[U.]  #20  gst-libav                    1.22.7 -> 1.22.8
[U.]  #21  gst-plugins-bad              1.22.7 -> 1.22.8
[U.]  #22  gst-plugins-base             1.22.7 x2, 1.22.7-dev -> 1.22.8 x2, 1.22.8-dev
[U.]  #23  gst-plugins-good             1.22.7 x2 -> 1.22.8 x2
[U.]  #24  gst-plugins-ugly             1.22.7 -> 1.22.8
[U.]  #25  gst-rtsp-server              1.22.7 -> 1.22.8
[U.]  #26  gstreamer                    1.22.7 x2, 1.22.7-bin, 1.22.7-dev -> 1.22.8 x2, 1.22.8-bin, 1.22.8-dev
[U.]  #27  gtk4                         4.12.3 -> 4.12.4
[U*]  #28  gvfs                         1.52.1 x2 -> 1.52.2 x2
[U.]  #29  initrd-linux                 6.1.69 -> 6.1.74
[U.]  #30  jq                           1.7, 1.7-bin, 1.7-doc, 1.7-lib, 1.7-man -> 1.7.1, 1.7.1-bin, 1.7.1-doc, 1.7.1-lib, 1.7.1-man
[U.]  #31  karchive                     5.112.0 -> 5.113.0
[U.]  #32  kauth                        5.112.0 -> 5.113.0
[U.]  #33  kcodecs                      5.112.0 -> 5.113.0
[U.]  #34  kconfig                      5.112.0 -> 5.113.0
[U.]  #35  kconfigwidgets               5.112.0 -> 5.113.0
[U.]  #36  kcoreaddons                  5.112.0, 5.112.0-bin -> 5.113.0, 5.113.0-bin
[U.]  #37  kcrash                       5.112.0 -> 5.113.0
[U.]  #38  kdbusaddons                  5.112.0 -> 5.113.0
[U.]  #39  kdoctools                    5.112.0 -> 5.113.0
[U.]  #40  kguiaddons                   5.112.0 -> 5.113.0
[U.]  #41  ki18n                        5.112.0, 5.112.0-bin -> 5.113.0, 5.113.0-bin
[U.]  #42  kiconthemes                  5.112.0, 5.112.0-bin -> 5.113.0, 5.113.0-bin
[U.]  #43  kitemviews                   5.112.0 -> 5.113.0
[U.]  #44  knotifications               5.112.0, 5.112.0-bin -> 5.113.0, 5.113.0-bin
[U.]  #45  kwidgetsaddons               5.112.0 -> 5.113.0
[U.]  #46  kwindowsystem                5.112.0 -> 5.113.0
[U.]  #47  libaom                       3.7.0 -> 3.7.1
[U.]  #48  libblockdev                  3.0.3 -> 3.0.4
[U.]  #49  libde265                     1.0.12 -> 1.0.15
[U*]  #50  libreoffice                  7.5.7.1, 7.5.7.1-wrapped -> 7.5.9.2, 7.5.9.2-wrapped
[U.]  #51  libsecret                    0.21.1 -> 0.21.2
[U.]  #52  libssh                       0.10.5 x2 -> 0.10.6 x2
[U.]  #53  linux                        6.1.69, 6.1.69-modules-shrunk -> 6.1.74, 6.1.74-modules-shrunk
[U.]  #54  mupdf                        1.23.5, 1.23.5-bin -> 1.23.6, 1.23.6-bin
[U.]  #55  mutter                       45.2 -> 45.3
[U.]  #56  nixos-system-rainbow-planet  23.11.20231226.ad9ca03 -> 23.11.20240126.205d4e3
[C.]  #57  nss                          3.90, 3.90-dev, 3.96.1 -> 3.90.1, 3.90.1-dev, 3.97
[U*]  #58  orca                         45.1 -> 45.2
[C*]  #59  perl                         <none>, 5.38.0, 5.38.0-env x4, 5.38.0-man -> <none>, 5.38.2, 5.38.2-env x4, 5.38.2-man
[U*]  #60  pipewire                     0.3.85 x2, 0.3.85-doc, 0.3.85-man -> 1.0.0 x2, 1.0.0-doc, 1.0.0-man
[U.]  #61  python3.11-gst-python        1.22.7 -> 1.22.8
[C.]  #62  qtbase                       5.15.11, 5.15.11-bin, 6.6.1 -> 5.15.12, 5.15.12-bin, 6.6.1
[C.]  #63  qtdeclarative                5.15.11, 5.15.11-bin, 6.6.1 -> 5.15.12, 5.15.12-bin, 6.6.1
[U.]  #64  qtquickcontrols              5.15.11 -> 5.15.12
[U.]  #65  qtsvg                        5.15.11, 5.15.11-bin -> 5.15.12, 5.15.12-bin
[C.]  #66  qttools                      5.15.11, 5.15.11-bin, 6.6.1 -> 5.15.12, 5.15.12-bin, 6.6.1
[C.]  #67  qttranslations               5.15.11, 6.6.1 -> 5.15.12, 6.6.1
[C.]  #68  qtwayland                    5.15.11, 5.15.11-bin, 6.6.1 -> 5.15.12, 5.15.12-bin, 6.6.1
[U.]  #69  qtx11extras                  5.15.11 -> 5.15.12
[U.]  #70  roc-toolkit                  0.2.5 x2 -> 0.3.0 x2
[U*]  #71  rygel                        0.42.4 -> 0.42.5
[U*]  #72  shadow                       4.14.1, 4.14.1-man, 4.14.1-su -> 4.14.2, 4.14.2-man, 4.14.2-su
[U*]  #73  snapshot                     45.1 -> 45.2
[U*]  #74  tailscale                    1.54.0 -> 1.58.2
[U.]  #75  vim-full                     9.0.2048 -> 9.0.2116
[U*]  #76  xorg-server                  21.1.9 -> 21.1.11
[U*]  #77  xwayland                     23.2.3 -> 23.2.4
Added packages:
[A.]  #01  chafa                             1.12.5
[A.]  #02  ddcutil                           2.0.0
[A.]  #03  fastfetch                         2.2.3
[A.]  #04  flatpak-state.json                <none>
[A.]  #05  imagemagick                       7.1.1-25 x2
[A.]  #06  liblqr                            1-0.4.2
[A.]  #07  libraw                            0.21.1-lib
[A.]  #08  nvd                               0.2.3
[A.]  #09  ocl-icd                           2.3.2
[A.]  #10  opencl-headers                    2023.02.06
[A.]  #11  perl5.38.2-Authen-SASL            2.1700
[A.]  #12  perl5.38.2-CGI                    4.59
[A.]  #13  perl5.38.2-CGI-Fast               2.16
[A.]  #14  perl5.38.2-Clone                  0.46
[A.]  #15  perl5.38.2-Config-IniFiles        3.000003
[A.]  #16  perl5.38.2-DBD-SQLite             1.74
[A.]  #17  perl5.38.2-DBI                    1.643
[A.]  #18  perl5.38.2-Digest-HMAC            1.04
[A.]  #19  perl5.38.2-Encode-Locale          1.05
[A.]  #20  perl5.38.2-FCGI                   0.82
[A.]  #21  perl5.38.2-FCGI-ProcManager       0.28
[A.]  #22  perl5.38.2-File-BaseDir           0.09
[A.]  #23  perl5.38.2-File-DesktopEntry      0.22
[A.]  #24  perl5.38.2-File-Listing           6.16
[A.]  #25  perl5.38.2-File-MimeInfo          0.33
[A.]  #26  perl5.38.2-File-Slurp             9999.32
[A.]  #27  perl5.38.2-HTML-Parser            3.81
[A.]  #28  perl5.38.2-HTML-TagCloud          0.38
[A.]  #29  perl5.38.2-HTML-Tagset            3.20
[A.]  #30  perl5.38.2-HTTP-CookieJar         0.014
[A.]  #31  perl5.38.2-HTTP-Cookies           6.10
[A.]  #32  perl5.38.2-HTTP-Daemon            6.16
[A.]  #33  perl5.38.2-HTTP-Date              6.06
[A.]  #34  perl5.38.2-HTTP-Message           6.45
[A.]  #35  perl5.38.2-HTTP-Negotiate         6.01
[A.]  #36  perl5.38.2-IO-HTML                1.004
[A.]  #37  perl5.38.2-IO-Socket-SSL          2.083
[A.]  #38  perl5.38.2-IO-Stringy             2.113
[A.]  #39  perl5.38.2-IPC-System-Simple      1.30
[A.]  #40  perl5.38.2-JSON                   4.10
[A.]  #41  perl5.38.2-LWP-MediaTypes         6.04
[A.]  #42  perl5.38.2-Mozilla-CA             20230821
[A.]  #43  perl5.38.2-Net-DBus               1.2.0
[A.]  #44  perl5.38.2-Net-HTTP               6.23
[A.]  #45  perl5.38.2-Net-SMTP-SSL           1.04
[A.]  #46  perl5.38.2-Net-SSLeay             1.92
[A.]  #47  perl5.38.2-String-ShellQuote      1.04
[A.]  #48  perl5.38.2-TermReadKey            2.38
[A.]  #49  perl5.38.2-Test-Fatal             0.017
[A.]  #50  perl5.38.2-Test-Needs             0.002010
[A.]  #51  perl5.38.2-Test-RequiresInternet  0.05
[A.]  #52  perl5.38.2-TimeDate               2.33
[A.]  #53  perl5.38.2-Try-Tiny               0.31
[A.]  #54  perl5.38.2-URI                    5.21
[A.]  #55  perl5.38.2-WWW-RobotRules         6.02
[A.]  #56  perl5.38.2-X11-Protocol           0.56
[A.]  #57  perl5.38.2-XML-Parser             2.46
[A.]  #58  perl5.38.2-XML-Twig               3.52
[A.]  #59  perl5.38.2-libnet                 3.15
[A.]  #60  perl5.38.2-libwww-perl            6.72
[A.]  #61  perl5.38.2-rename                 1.11
[A.]  #62  potrace                           1.16
[A.]  #63  rpm                               4.18.1
[A.]  #64  yyjson                            0.8.0
Removed packages:
[R.]  #01  initrd-kmod-blacklist-ubuntu      <none>
[R.]  #02  libaccounts-glib                  1.24
[R.]  #03  perl5.38.0-Authen-SASL            2.1700
[R.]  #04  perl5.38.0-CGI                    4.59
[R.]  #05  perl5.38.0-CGI-Fast               2.16
[R.]  #06  perl5.38.0-Clone                  0.46
[R.]  #07  perl5.38.0-Config-IniFiles        3.000003
[R.]  #08  perl5.38.0-DBD-SQLite             1.74
[R.]  #09  perl5.38.0-DBI                    1.643
[R.]  #10  perl5.38.0-Digest-HMAC            1.04
[R.]  #11  perl5.38.0-Encode-Locale          1.05
[R.]  #12  perl5.38.0-FCGI                   0.82
[R.]  #13  perl5.38.0-FCGI-ProcManager       0.28
[R.]  #14  perl5.38.0-File-BaseDir           0.09
[R.]  #15  perl5.38.0-File-DesktopEntry      0.22
[R.]  #16  perl5.38.0-File-Listing           6.16
[R.]  #17  perl5.38.0-File-MimeInfo          0.33
[R.]  #18  perl5.38.0-File-Slurp             9999.32
[R.]  #19  perl5.38.0-HTML-Parser            3.81
[R.]  #20  perl5.38.0-HTML-TagCloud          0.38
[R.]  #21  perl5.38.0-HTML-Tagset            3.20
[R.]  #22  perl5.38.0-HTTP-CookieJar         0.014
[R.]  #23  perl5.38.0-HTTP-Cookies           6.10
[R.]  #24  perl5.38.0-HTTP-Daemon            6.16
[R.]  #25  perl5.38.0-HTTP-Date              6.06
[R.]  #26  perl5.38.0-HTTP-Message           6.45
[R.]  #27  perl5.38.0-HTTP-Negotiate         6.01
[R.]  #28  perl5.38.0-IO-HTML                1.004
[R.]  #29  perl5.38.0-IO-Socket-SSL          2.083
[R.]  #30  perl5.38.0-IO-Stringy             2.113
[R.]  #31  perl5.38.0-IPC-System-Simple      1.30
[R.]  #32  perl5.38.0-JSON                   4.10
[R.]  #33  perl5.38.0-LWP-MediaTypes         6.04
[R.]  #34  perl5.38.0-Mozilla-CA             20230821
[R.]  #35  perl5.38.0-Net-DBus               1.2.0
[R.]  #36  perl5.38.0-Net-HTTP               6.23
[R.]  #37  perl5.38.0-Net-SMTP-SSL           1.04
[R.]  #38  perl5.38.0-Net-SSLeay             1.92
[R.]  #39  perl5.38.0-String-ShellQuote      1.04
[R.]  #40  perl5.38.0-TermReadKey            2.38
[R.]  #41  perl5.38.0-Test-Fatal             0.017
[R.]  #42  perl5.38.0-Test-Needs             0.002010
[R.]  #43  perl5.38.0-Test-RequiresInternet  0.05
[R.]  #44  perl5.38.0-TimeDate               2.33
[R.]  #45  perl5.38.0-Try-Tiny               0.31
[R.]  #46  perl5.38.0-URI                    5.21
[R.]  #47  perl5.38.0-WWW-RobotRules         6.02
[R.]  #48  perl5.38.0-X11-Protocol           0.56
[R.]  #49  perl5.38.0-XML-Parser             2.46
[R.]  #50  perl5.38.0-XML-Twig               3.52
[R.]  #51  perl5.38.0-libnet                 3.15
[R.]  #52  perl5.38.0-libwww-perl            6.72
[R.]  #53  perl5.38.0-rename                 1.11
Closure size: 2168 -> 2180 (2135 paths added, 2123 paths removed, delta +12, disk usage +647.1MiB).
```