### PR TITLE
Fix nvim config

### DIFF
--- a/modules/home-manager/files/nvim/lua/plugins/none-ls.lua
+++ b/modules/home-manager/files/nvim/lua/plugins/none-ls.lua
@@ -10,7 +10,6 @@ return {
 			require("mason-null-ls").setup({
 				ensure_installed = {
 					"prettier", -- HTML, JS, JSON, etc.
-					"ruff", -- Pyhton
 					"stylua", -- LUA
 				},
 			})
@@ -28,11 +27,9 @@ return {
 					null_ls.builtins.completion.spell,
 					null_ls.builtins.diagnostics.puppet_lint,
 					null_ls.builtins.diagnostics.rubocop,
-					null_ls.builtins.diagnostics.ruff,
 					null_ls.builtins.formatting.prettier,
 					null_ls.builtins.formatting.puppet_lint,
 					null_ls.builtins.formatting.rubocop,
-					null_ls.builtins.formatting.ruff_format,
 					null_ls.builtins.formatting.stylua,
 				},
 			})


### PR DESCRIPTION
none-ls removed ruff because ruff-lsp should be used instead, which I have.
