### PR TITLE
nix 24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,16 +19,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1727016223,
-        "narHash": "sha256-iZqd91Cp4O02BU6/eBZ0UZgJN8AlwH+0geQUpqF176E=",
+        "lastModified": 1731323744,
+        "narHash": "sha256-SxUQm4cTHcaoPQHoXe26ZV8cZiMWBGow8MjE4L+MckM=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "916044581862c32fc2365e8e9ff0b1507a98925e",
+        "rev": "254bf3fe9d8fa2e1b2fb55dbcf535b2d870180c4",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.3.24",
+        "ref": "4.4.5",
         "repo": "brew",
         "type": "github"
       }
@@ -41,11 +41,11 @@
         "onchg": "onchg"
       },
       "locked": {
-        "lastModified": 1728874779,
-        "narHash": "sha256-498cQTDaU7bU3CbWPCQgSGkV25T8sZQmMwhU58WkIXE=",
+        "lastModified": 1732416782,
+        "narHash": "sha256-evu/J6D79rlQ6oYtKgZxpWvT6ORt0SH573R6IOIS6R0=",
         "owner": "aksiksi",
         "repo": "compose2nix",
-        "rev": "07cad037b8887ba94cd7236ffd1a8ee47002a9fe",
+        "rev": "a81c2e5e485c722e74dce7c8e308c7b0a1381854",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731274291,
-        "narHash": "sha256-cZ0QMpv5p2a6WEE+o9uu0a4ma6RzQDOQTbm7PbixWz8=",
+        "lastModified": 1732988076,
+        "narHash": "sha256-2uMaVAZn7fiyTUGhKgleuLYe5+EAAYB/diKxrM7g3as=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "486250f404f4a4f4f33f8f669d83ca5f6e6b7dfc",
+        "rev": "2814a5224a47ca19e858e027f7e8bff74a8ea9f1",
         "type": "github"
       },
       "original": {
@@ -321,16 +321,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1726989464,
-        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
+        "lastModified": 1733050161,
+        "narHash": "sha256-lYnT+EYE47f5yY3KS/Kd4pJ6CO9fhCqumkYYkQ3TK20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
+        "rev": "62d536255879be574ebfe9b87c4ac194febf47c5",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731454423,
-        "narHash": "sha256-TtwvgFxUa0wyptLhQbKaixgNW1UXf3+TDqfX3Kp63oM=",
+        "lastModified": 1733105089,
+        "narHash": "sha256-Qs3YmoLYUJ8g4RkFj2rMrzrP91e4ShAioC9s+vG6ENM=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6c71c49e2448e51ad830ed211024e6d0edc50116",
+        "rev": "c6b65d946097baf3915dd51373251de98199280d",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1730108712,
-        "narHash": "sha256-vIvmXmjAQIY39hACGFe/cdBK2r3ZprpHLwX2HIy7Mj8=",
+        "lastModified": 1732867134,
+        "narHash": "sha256-YGtFJ/4SE37evvHX+OkS2klRdHlO7HvovaaxR/yWuWg=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "1cba177bb0a948c919af7596e40bef307543d40a",
+        "rev": "01ca2cbd9fb5c29d73fac327f5a9a2a1a222e218",
         "type": "github"
       },
       "original": {
@@ -396,11 +396,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1731434956,
-        "narHash": "sha256-WmEUrnmLxqUg1ltf1x0LKb9RZr4mrqu9OtHKlVC1m7s=",
+        "lastModified": 1732145543,
+        "narHash": "sha256-VRQh/lvCSko9YV7haXyPt7DSp+EkgjjBv/9U4cY9c50=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "2ed1e70db2448bd997b7b0c52f7bef42ac7a51a7",
+        "rev": "ac3945ee614f69ab89c6935b3f0567028de5f012",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1731381599,
-        "narHash": "sha256-W+FuVxCdCiw7IaAWPajq9iOuM57zITFnbkw2ZQXfW9I=",
+        "lastModified": 1733095793,
+        "narHash": "sha256-woqkmcGxOleK1RyoZpXU3NaC4+epr2qYau2mVhVQFjY=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "23976d5dac8b0f07187bc3c95e3812304519e5e3",
+        "rev": "e468c8b79dd55f1ce8803887d3593fb0016f1f81",
         "type": "github"
       },
       "original": {
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1731403644,
-        "narHash": "sha256-T9V7CTucjRZ4Qc6pUEV/kpgNGzQbHWfGcfK6JJLfUeI=",
+        "lastModified": 1733139194,
+        "narHash": "sha256-PVQW9ovo0CJbhuhCsrhFJGGdD1euwUornspKpBIgdok=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f6581f1c3b137086e42a08a906bdada63045f991",
+        "rev": "c6c90887f84c02ce9ebf33b95ca79ef45007bf88",
         "type": "github"
       },
       "original": {
@@ -579,11 +579,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1729156928,
-        "narHash": "sha256-+D0R2rH2pEhzJ3zZGc5Oj5KGtnkO43sCWYNbq0ptuao=",
+        "lastModified": 1732844581,
+        "narHash": "sha256-BwHD1d6Bl5LL/HciTf+mQmBN3I3S6nYqcB+5BXVozNk=",
         "owner": "stackbuilders",
         "repo": "nixpkgs-terraform",
-        "rev": "db8dc49e397acf87d5b542755717bae368d32f3c",
+        "rev": "b4db1b59d8f62cd37b6f9540e368d0e2627c4a2d",
         "type": "github"
       },
       "original": {
@@ -594,11 +594,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1731245184,
-        "narHash": "sha256-vmLS8+x+gHRv1yzj3n+GTAEObwmhxmkkukB2DwtJRdU=",
+        "lastModified": 1733064805,
+        "narHash": "sha256-7NbtSLfZO0q7MXPl5hzA0sbVJt6pWxxtGWbaVUDDmjs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aebe249544837ce42588aa4b2e7972222ba12e8f",
+        "rev": "31d66ae40417bb13765b0ad75dd200400e98de84",
         "type": "github"
       },
       "original": {
@@ -639,16 +639,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1731239293,
-        "narHash": "sha256-q2yjIWFFcTzp5REWQUOU9L6kHdCDmFDpqeix86SOvDc=",
+        "lastModified": 1732981179,
+        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9256f7c71a195ebe7a218043d9f93390d49e6884",
+        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -744,11 +744,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731292155,
-        "narHash": "sha256-fYVoUUtSadbOrH0z0epVQDsStBDS/S/fAK//0ECQAAI=",
+        "lastModified": 1732933841,
+        "narHash": "sha256-dge02pUSe2QeC/B3PriA0R8eAX+EU3aDoXj9FcS3XDw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7c4cd99ed7604b79e8cb721099ac99c66f656b3a",
+        "rev": "c65e91d4a33abc3bc4a892d3c5b5b378bad64ea1",
         "type": "github"
       },
       "original": {
@@ -788,17 +788,14 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1731364708,
-        "narHash": "sha256-HC0anOL+KmUQ2hdRl0AtunbAckasxrkn4VLmxbW/WaA=",
+        "lastModified": 1733128155,
+        "narHash": "sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "4c91d52db103e757fc25b58998b0576ae702d659",
+        "rev": "c6134b6fff6bda95a1ac872a2a9d5f32e3c37856",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
     # Where we get most of our software. Giant mono repo with recipes
     # called derivations that say how to build software.
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     compose2nix = {
@@ -30,7 +30,7 @@
 
     # Manages things in home directory
     home-manager = {
-      url = "github:nix-community/home-manager/release-24.05";
+      url = "github:nix-community/home-manager/release-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -71,7 +71,6 @@
     sops-nix = {
       url = "github:mic92/sops-nix";
       inputs.nixpkgs.follows ="nixpkgs";
-      inputs.nixpkgs-stable.follows = "nixpkgs";
     };
 
   }; # end inputs

--- a/modules/home-manager/common/hm-sops.nix
+++ b/modules/home-manager/common/hm-sops.nix
@@ -1,14 +1,14 @@
-{ pkgs, hostname, username, ... }: {
+{ config, pkgs, hostname, username, ... }: {
   home.packages = with pkgs; [
     home-manager
   ];
 
   sops = {
-    age.keyFile = /home/${username}/.config/sops/age/keys.txt;
+    age.keyFile = "${config.users.users.${username}.home}/.config/sops/age/keys.txt";
     defaultSopsFile = ../hosts/${hostname}/secrets.yaml;
     secrets = {
-      local_git_config.path = "/home/${username}/.gitconfig-local";
-      local_private_env.path = "/home/${username}/.private-env";
+      local_git_config.path = "${config.users.users.${username}.home}/.gitconfig-local";
+      local_private_env.path = "${config.users.users.${username}.home}/.private-env";
     };
   };
 }

--- a/modules/hosts/nixos/bigboy/default.nix
+++ b/modules/hosts/nixos/bigboy/default.nix
@@ -151,16 +151,16 @@
   };
 
   sops = {
-    age.keyFile = /home/${username}/.config/sops/age/keys.txt;
+    age.keyFile = "${config.users.users.${username}.home}/.config/sops/age/keys.txt";
     defaultSopsFile = ./secrets.yaml;
     secrets = {
       local_git_config = {
         owner = "${username}";
-        path = "/home/${username}/.gitconfig-local";
+        path = "${config.users.users.${username}.home}/.gitconfig-local";
       };
       local_private_env = {
         owner = "${username}";
-        path = "/home/${username}/.private-env";
+        path = "${config.users.users.${username}.home}/.private-env";
       };
     };
   };

--- a/modules/hosts/nixos/hetznix01/default.nix
+++ b/modules/hosts/nixos/hetznix01/default.nix
@@ -78,9 +78,9 @@
         "2a01:4ff:ff00::add:2"
       ];
       routes = [
-        { routeConfig = { Destination = "172.31.1.1"; }; }
-        { routeConfig = { Gateway = "172.31.1.1"; GatewayOnLink = true; }; }
-        { routeConfig.Gateway = "fe80::1"; }
+        { Destination = "172.31.1.1"; }
+        { Gateway = "172.31.1.1"; GatewayOnLink = true; }
+        { Gateway = "fe80::1"; }
       ];
       # make the routes on this interface a dependency for network-online.target
       linkConfig.RequiredForOnline = "routable";

--- a/modules/hosts/nixos/hetznix01/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/default.nix
@@ -76,16 +76,16 @@ in {
   };
 
   sops = {
-    age.keyFile = /home/${username}/.config/sops/age/keys.txt;
+    age.keyFile = "${config.users.users.${username}.home}/.config/sops/age/keys.txt";
     defaultSopsFile = ../secrets.yaml;
     secrets = {
       local_git_config = {
         owner = "${username}";
-        path = "/home/${username}/.gitconfig-local";
+        path = "${config.users.users.${username}.home}/.gitconfig-local";
       };
       local_private_env = {
         owner = "${username}";
-        path = "/home/${username}/.private-env";
+        path = "${config.users.users.${username}.home}/.private-env";
       };
       matrix_secrets_yaml = {
         owner = config.users.users.matrix-synapse.name;

--- a/modules/hosts/nixos/hetznix02/default.nix
+++ b/modules/hosts/nixos/hetznix02/default.nix
@@ -65,9 +65,9 @@
         "2a01:4ff:ff00::add:2"
       ];
       routes = [
-        { routeConfig = { Destination = "172.31.1.1"; }; }
-        { routeConfig = { Gateway = "172.31.1.1"; GatewayOnLink = true; }; }
-        { routeConfig.Gateway = "fe80::1"; }
+        { Destination = "172.31.1.1"; }
+        { Gateway = "172.31.1.1"; GatewayOnLink = true; }
+        { Gateway = "fe80::1"; }
       ];
       # make the routes on this interface a dependency for network-online.target
       linkConfig.RequiredForOnline = "routable";

--- a/modules/hosts/nixos/hetznix02/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix02/post-install/default.nix
@@ -1,15 +1,15 @@
-{ username, ... }: {
+{ config, username, ... }: {
   sops = {
-    age.keyFile = /home/${username}/.config/sops/age/keys.txt;
+    age.keyFile = "${config.users.users.${username}.home}/.config/sops/age/keys.txt";
     defaultSopsFile = ../secrets.yaml;
     secrets = {
       local_git_config = {
         owner = "${username}";
-        path = "/home/${username}/.gitconfig-local";
+        path = "${config.users.users.${username}.home}/.gitconfig-local";
       };
       local_private_env = {
         owner = "${username}";
-        path = "/home/${username}/.private-env";
+        path = "${config.users.users.${username}.home}/.private-env";
       };
       tailscale_key = {
         restartUnits = [ "tailscaled-autoconnect.service" ];

--- a/modules/hosts/nixos/nixnas1/default.nix
+++ b/modules/hosts/nixos/nixnas1/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, username, ... }: {
+{ config, pkgs, username, ... }: {
   imports = [
     ./disk-config.nix
     ./hardware-configuration.nix
@@ -62,16 +62,16 @@
   };
 
   sops = {
-    age.keyFile = /home/${username}/.config/sops/age/keys.txt;
+    age.keyFile = "${config.users.users.${username}.home}/.config/sops/age/keys.txt";
     defaultSopsFile = ./secrets.yaml;
     secrets = {
       local_git_config = {
         owner = "${username}";
-        path = "/home/${username}/.gitconfig-local";
+        path = "${config.users.users.${username}.home}/.gitconfig-local";
       };
       local_private_env = {
         owner = "${username}";
-        path = "/home/${username}/.private-env";
+        path = "${config.users.users.${username}.home}/.private-env";
       };
     };
   };

--- a/modules/hosts/nixos/nixnas1/default.nix
+++ b/modules/hosts/nixos/nixnas1/default.nix
@@ -76,8 +76,6 @@
     };
   };
 
-  sound.enable = false;
-
   systemd.network = {
     enable = true;
     netdevs = {

--- a/modules/hosts/nixos/nixnuc/containers/audiobookshelf.nix
+++ b/modules/hosts/nixos/nixnuc/containers/audiobookshelf.nix
@@ -5,15 +5,14 @@ in {
   # Audiobookshelf
 
   #############################################################################
-  # I am using v2.8.1 because that is both the current Docker image and       #
-  # the current version in nixpkgs unstable. My plan is to switch from Podman #
-  # to a systemd-nspawn container.                                            #
+  # I am using v2.17.2 because that is the current one in nix 24.11.          #
+  # My plan is to switch from Podman to the native NixOS service              #
   #############################################################################
 
   virtualisation.oci-containers.containers = {
     "audiobookshelf" = {
       autoStart = true;
-      image = "ghcr.io/advplyr/audiobookshelf:2.8.1";
+      image = "ghcr.io/advplyr/audiobookshelf:2.17.2";
       environment = {
         AUDIOBOOKSHELF_UID = "99";
         AUDIOBOOKSHELF_GID = "100";

--- a/modules/hosts/nixos/nixnuc/containers/audiobookshelf.nix
+++ b/modules/hosts/nixos/nixnuc/containers/audiobookshelf.nix
@@ -1,5 +1,5 @@
 { ... }: let
-  volume_base = "/orico/audiobookshelf";
+  volume_base = "/var/lib/audiobookshelf";
   http_port = "13378";
 in {
   # Audiobookshelf

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -221,7 +221,7 @@ in {
     nextcloud = {
       enable = true;
       hostName = "nextcloud.home.technicalissues.us";
-      package = pkgs.nextcloud29; # Need to manually increment with every major upgrade.
+      package = pkgs.nextcloud30; # Need to manually increment with every major upgrade.
       appstoreEnable = true;
       autoUpdateApps.enable = true;
       config = {

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -81,7 +81,6 @@ in {
         3000  # PsiTransfer in oci-container
         3030  # Forgejo
         8001  # Tube Archivist
-        8080  # Tandoor in docker compose
         8384  # Syncthing gui
         8888  # Atuin
         8090  # Wallabag in docker compose
@@ -419,14 +418,6 @@ in {
           forceSSL = true;
           locations."/".proxyPass = "http://${backend_ip}:8090";
         };
-        "tandoor.${home_domain}" = {
-          listen = [{ port = https_port; addr = "0.0.0.0"; ssl = true; }];
-          enableACME = true;
-          acmeRoot = null;
-          forceSSL = true;
-          locations."/".proxyPass = "http://${backend_ip}:8080";
-          locations."/media/".alias = "/orico/tandoor-recipes/";
-        };
       };
     };
     postgresql = {
@@ -443,7 +434,6 @@ in {
       config.services.forgejo.stateDir
       config.services.mealie.settings.DATA_DIR
       config.services.nextcloud.home
-      "${config.users.users.${username}.home}/compose-files/tandoor"
       "${config.users.users.${username}.home}/compose-files/wallabag"
       "/orico/immich/library"
       "/orico/jellyfin/data"
@@ -455,32 +445,6 @@ in {
       dataDir = "/orico/syncthing";
       openDefaultPorts = true;
       guiAddress = "0.0.0.0:8384";
-    };
-    tandoor-recipes = {
-      enable = true;
-      address = "0.0.0.0";
-      extraConfig = {
-        #ALLOWED_HOSTS=*
-        #COMMENT_PREF_DEFAULT=1
-        DB_ENGINE = "django.db.backends.postgresql";
-        #DEBUG=0
-        #DEBUG_TOOLBAR=0
-        #FRACTION_PREF_DEFAULT=0
-        #GUNICORN_MEDIA=0
-        POSTGRES_DB = "tandoor";
-        POSTGRES_HOST = "127.0.0.1";
-        # This sucks, but this module doesn't support pulling the password from a file
-        POSTGRES_PASSWORD = "yummy-flat-bread-with-garlic";
-        POSTGRES_PORT = 5432;
-        POSTGRES_USER = "tandoor";
-        #REMOTE_USER_AUTH=0
-        SECRET_KEY_FILE = config.sops.secrets.tandoor_secret_key.path;
-        #SHOPPING_MIN_AUTOSYNC_INTERVAL=5
-        #SQL_DEBUG=0
-
-        MEDIA_ROOT = "/orico/tandoor-recipes/mediafiles";
-      };
-      port = 8080;
     };
     zfs.autoScrub.enable = true;
   };
@@ -499,10 +463,6 @@ in {
       };
       mealie.mode = "0444";
       nextcloud_admin_pass.owner = config.users.users.nextcloud.name;
-      tandoor_db_pass.mode = "0444";
-      tandoor_db_pass.path = "/orico/tandoor-recipes/.dbpass";
-      tandoor_secret_key.mode = "0444";
-      tandoor_secret_key.path = "/orico/tandoor-recipes/.skey";
     };
   };
 

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -42,7 +42,7 @@ in {
     yt-dlp
   ];
 
-  hardware.opengl = {
+  hardware.graphics = {
     enable = true;
     extraPackages = with pkgs; [
       intel-media-driver

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -122,7 +122,6 @@ in {
   ];
 
   # Enable sound with pipewire.
-  sound.enable = true;
   hardware.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -486,16 +486,16 @@ in {
   };
 
   sops = {
-    age.keyFile = /home/${username}/.config/sops/age/keys.txt;
+    age.keyFile = "${config.users.users.${username}.home}/.config/sops/age/keys.txt";
     defaultSopsFile = ./secrets.yaml;
     secrets = {
       local_git_config = {
         owner = "${username}";
-        path = "/home/${username}/.gitconfig-local";
+        path = "${config.users.users.${username}.home}/.gitconfig-local";
       };
       local_private_env = {
         owner = "${username}";
-        path = "/home/${username}/.private-env";
+        path = "${config.users.users.${username}.home}/.private-env";
       };
       mealie.mode = "0444";
       nextcloud_admin_pass.owner = config.users.users.nextcloud.name;

--- a/modules/hosts/nixos/nixnuc/hardware-configuration.nix
+++ b/modules/hosts/nixos/nixnuc/hardware-configuration.nix
@@ -23,6 +23,11 @@
       fsType = "vfat";
     };
 
+  fileSystems."/var/lib/audiobookshelf" =
+    { device = "orico/audiobookshelf";
+      fsType = "zfs";
+    };
+
   swapDevices = [ ];
 
   # Enables DHCP on each ethernet and wireless interface. In case of scripted networking

--- a/modules/hosts/nixos/rainbow-planet/default.nix
+++ b/modules/hosts/nixos/rainbow-planet/default.nix
@@ -125,16 +125,16 @@
   };
 
   sops = {
-    age.keyFile = /home/${username}/.config/sops/age/keys.txt;
+    age.keyFile = "${config.users.users.${username}.home}/.config/sops/age/keys.txt";
     defaultSopsFile = ./secrets.yaml;
     secrets = {
       local_git_config = {
         owner = "${username}";
-        path = "/home/${username}/.gitconfig-local";
+        path = "${config.users.users.${username}.home}/.gitconfig-local";
       };
       local_private_env = {
         owner = "${username}";
-        path = "/home/${username}/.private-env";
+        path = "${config.users.users.${username}.home}/.private-env";
       };
       tailscale_key = {
         restartUnits = [ "tailscaled-autoconnect.service" ];

--- a/modules/hosts/nixos/rainbow-planet/default.nix
+++ b/modules/hosts/nixos/rainbow-planet/default.nix
@@ -114,7 +114,6 @@
   };
 
   # Enable sound with pipewire.
-  sound.enable = true;
   hardware.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {

--- a/modules/system/common/all-darwin.nix
+++ b/modules/system/common/all-darwin.nix
@@ -93,7 +93,6 @@
         "auto-allocate-uids"
         "flakes"
         "nix-command"
-        "repl-flake"
       ];
       # extra-substituters = [
       # ];

--- a/modules/system/common/linux/lets-encrypt.nix
+++ b/modules/system/common/linux/lets-encrypt.nix
@@ -20,7 +20,7 @@
   };
 
   sops = {
-    age.keyFile = /home/${username}/.config/sops/age/keys.txt;
+    age.keyFile = "${config.users.users.${username}.home}/.config/sops/age/keys.txt";
     secrets.gandi_api.sopsFile = ../secrets.yaml;
   };
 }


### PR DESCRIPTION
- Update flake to nix and home manager 24.11
- 24.11 removes the sound.enable setting
- Replace absolute path /home
- Remove unknown setting while updating to nix 24.11
- Update setting name for nix 24.11: opengl --> graphics
- Nix 24.11 brings Nextcloud 30!
- Update Audiobookshelf container
- Remove Tandoor - replaced with Mealie
- Change Audiobookshelf mountpoint to service's default
- Update syntax for systemd.network routes
