### PR TITLE
Enhance nixdiff alias on Mac to represent reality

### DIFF
--- a/modules/hosts/darwin/home.nix
+++ b/modules/hosts/darwin/home.nix
@@ -17,7 +17,7 @@
     oh-my-zsh.plugins = [ "macos" ];
     shellAliases = {
       currentwifi = "networksetup -getairportnetwork en0 |cut -d ':' -f2- | cut -d ' ' -f2-";
-      nixdiff = "cd ~/repos/dots && darwin-rebuild build --flake . && nvd diff /run/current-system result";
+      nixdiff = "brew outdated && brew outdated --cask && mas outdated && cd ~/repos/dots && darwin-rebuild build --flake . && nvd diff /run/current-system result";
       nixup = "darwin-rebuild switch --flake ~/repos/dots";
       uwgconnect = "networksetup -setairportnetwork en0 SecureWest";
       uwgforget = "networksetup -removepreferredwirelessnetwork en0 SecureWest";


### PR DESCRIPTION
On macOS, nix-darwin and nix-homebrew are used. As a result, more than
just `nvd` is needed.