### PR TITLE
Fix MtnMeshBot: run as root, use tag, update .env

### DIFF
--- a/modules/hosts/nixos/nixnuc/containers/mountain-mesh-bot-discord.nix
+++ b/modules/hosts/nixos/nixnuc/containers/mountain-mesh-bot-discord.nix
@@ -6,9 +6,7 @@ in {
   virtualisation.oci-containers.containers = {
     "mtnmesh_bot_discord" = {
       autoStart = true;
-      image = "ghcr.io/genebean/mountain-mesh-bot-discord:main";
-      podman.user = username;
-      pull = "always";
+      image = "ghcr.io/genebean/mountain-mesh-bot-discord:v1.0.0";
       volumes = [
         "${volume_base}/.env:/src/.env"
       ];
@@ -18,7 +16,6 @@ in {
   services.restic.backups.daily.paths = [ volume_base ];
 
   sops.secrets.mtnmesh_bot_dot_env = {
-    owner = "${username}";
     path = "${volume_base}/.env";
     restartUnits = [ "${config.virtualisation.oci-containers.containers.mtnmesh_bot_discord.serviceName}" ];
   };

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -673,6 +673,7 @@ in {
     isNormalUser = true;
     description = "Gene Liverman";
     extraGroups = [ "docker" "podman" "networkmanager" "wheel" ];
+    linger = true;
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFvLaPTfG3r+bcbI6DV4l69UgJjnwmZNCQk79HXyf1Pt gene@rainbow-planet"
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6bRxR9wmwO1AcKjO2gRk6oxbIoDLI3KQL7sj92sN0K Gene on BigBoy"

--- a/modules/hosts/nixos/nixnuc/secrets.yaml
+++ b/modules/hosts/nixos/nixnuc/secrets.yaml
@@ -4,7 +4,7 @@ local_private_env: ENC[AES256_GCM,data:qOPXTS2uo/1jyVEKCtBvuK/dzZaPf1K5tHuSVF2hB
 home_assistant_token: ENC[AES256_GCM,data:fNpoH60rXAsoVx/NBoDobDw/e6IoeoZfef1uDR7HbmnHNI101b+kQKkB8wBXEDLf7MlqlXVc1ExlgYFUo7+h2msx4WZUCGzuHtp1cMP0O9s2PZoQU8KQM2Frd69vOUcOT5y5ShJZPRrf6H2UKrm//3jE9zDOxxy3cQj6Q+jQLXX4AfZ12JAKzSiee9URWdU8eCHbnquUl1RNHF7zZQ8Mr9m41sBOrpBXt7ErsrhxxRhwlk7qprLt,iv:1j/QmOkLYd7nA+wXS49drBHU09HzMP3XxPbPdaErV6E=,tag:ftyOeNaN5PwNebeMPNAmTg==,type:str]
 immich_kiosk_basic_auth: ENC[AES256_GCM,data:R/vaYXe0SRwSUg8zC367vA/OYhjIcgfbHxR3OhLt1YYUhPNXVuUGmn199zLD,iv:GBEjJKvbwHAS75negE2whTlI4wS8K2nQYNm3015DFoY=,tag:zs+bJEr9JlIrJtikHycN4g==,type:str]
 mealie: ENC[AES256_GCM,data:fZFBWlh/nbxK0GA6+fb1FK6aFfbiV/GsBYKYRPgavcsB9h4HwRSZN94gPQ3AfGnk1q08ORPBYShNUIaVdsf4+t3taDC7bNTwPqFGRxoeKOU15BPj6Fpw7SHlplApUg7RDmuTWZuXDH0F49N+09GU/Lc26ewHMAzL8CtGg/H7s3CQfFEqCYYcXJeUcnNDu6PRnKFIAppflSScREp29CUf/IfTYQXidQC25upZgcvGJ+dCTDyNFftlhQiFQh8nFRFVJfKk4iBqnig3fOYsTD32ohAotfDGsSUWb9yjoYQNnNn0V14/,iv:WRFiBtavTP3iP5YSaCMkd7ag8ccx1BO76Vlw6axPkJU=,tag:4BhAxbF8JUB0MV12yx86uQ==,type:str]
-mtnmesh_bot_dot_env: ENC[AES256_GCM,data:G74i0xyPaX0Ims19X5sTI35bs807BpZ3D3eS5gBgAVGxWglnTT/DsmlmFAq5lqGPjk4D61J4ts2rWKrm+9vYGjCzFuA3LE/HAUesqNey0jusMNUW8hFmkIA=,iv:0SeL7dU/KRR/wNQszw5YGPmxzkVCmy2wwTMlEZJY5P4=,tag:+QOweRVUEjv5m732e6lfHg==,type:str]
+mtnmesh_bot_dot_env: ENC[AES256_GCM,data:jKz0voG/a7Eq+zHI2fsejTpu5H+ic5ZE8VmtOQDQEOTvYT8GWr2oCGwh68ql7g+nU5hlNN7uLl9LreW59nTgmvWNCVjVNKchxJeydktMUoq2FlgyoC2I354bi9gFEL0X5JYRR7jG9iwy4WGyEFfhhUJn1MSwOurRZPw/tdWTUKQVwN5oqjMxkXrZhFLDzq6BrTs0hBpzRYTe,iv:ZBxHkW8VyU+8v4GiDJMEaeqm3Fdtuwm7M/7YXkfkMnw=,tag:S8hTOSicQNIAj/Gdxzw5+A==,type:str]
 nextcloud_admin_pass: ENC[AES256_GCM,data:KztB3Tkqlt73PEO41lthGYElrbwVdfqQgT6f,iv:kRwXqGJO4AUOMq+uYzndGhscaJiyvG4ANKabHHd78YM=,tag:dP3PgKafDTv8x7huKJGDqA==,type:str]
 psitransfer_dot_env: ENC[AES256_GCM,data:bhvU0AOCjecZ62BtLw4H1DdkLeatI+uUl6L7UkdDRkBF3sayO45Z1eR4q60tflXucyTGhT8WgKFz53I+C2dn265wzojIRc3Xr4TBLyWpfJ7/dct40SckgUiRvOnrefiriWQ=,iv:DGMhDkzgeupzzTJnCdVWDPUSo2wxI3MAypKQwVfHExE=,tag:KbteGqrkqgj2XB1lvlk/yQ==,type:str]
 tandoor_db_pass: ENC[AES256_GCM,data:X0unx5jquLsUXadbF6xLjjeGY+f8Ec4kdc15JQ==,iv:XptlJHfAkF+3jbgJTqxhVReYjuVVdk3NzfPepP78DRI=,tag:3RG5P9QGCJ/fjdxWpY1xWA==,type:str]
@@ -20,7 +20,7 @@ sops:
             bHZlNTZDV2NYU1hQQy9mem80SFF6TFkKfmjkJBfTdh0vTtGaVx1t3tHJvSsAwdYD
             PF025X9U+yG2oIopwXEVBkxcD70eyuJn3OqH0xoVLBkbhNM9i8LHrA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-08-15T11:56:01Z"
-    mac: ENC[AES256_GCM,data:ALYT6Z1FBs+Gw0fiGlYGNBiLKj6oczyUhyeBZDCR7Ypc4dF15J9XZAlTZS0RI7D6Eg9V2UokoKZAXeJZ/aM/MeBeGdqnYygd6dAr2yjg3Zq6t7Ea2uYCKniocOuz+RuFwhPKW70kD2KhjXwYDa/FPoZkQYdKiR7fS2jLiA49I38=,iv:V16tWj8/SMObnIGARbDFtE6EPIM8HxhW7G4GcXtTeDk=,tag:LMo6mURLxVwD9Su7PwqzLw==,type:str]
+    lastmodified: "2025-08-16T23:59:14Z"
+    mac: ENC[AES256_GCM,data:0LA6+4HwqHAlwvCLN0n8n3eo7bnzhwmmwUVxJ1jOmJzyYXwDQ84LqxS/A5gOevMigBlgNnwZ+8BQrWBS7/mBYV6PGWmjXN/qEXKdRMddtBDlHKENdGb+7DeGy8F77muTbwYR9GsnCROGvJZyOfVF6DFWZB6vRgdsiTP6VK6KD8c=,iv:NHUyvx2BCASzLZKRBiUc73F60/pwNQ2zNmQAEF2MuRE=,tag:zLIncSbtmnVEpFLt32EzNA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2


### PR DESCRIPTION
Prior to this, I had tried to run as my user but that doesn't work here.
It seems you have to use the version of running containers built into
home-manager if you want rootless podman.
