### PR TITLE
Add borders back to WezTerm so that the edges are not hidden

### DIFF
--- a/modules/shared/files/wezterm/wezterm.lua
+++ b/modules/shared/files/wezterm/wezterm.lua
@@ -11,7 +11,6 @@ local is_mac = wezterm.target_triple:find('darwin') ~= nil
 -- ==========================================
 config.font = wezterm.font('Hack Nerd Font')
 config.font_size = 13.0
-config.window_decorations = "RESIZE" -- Removes the bulky macOS title bar
 config.bold_brightens_ansi_colors = false
 config.enable_scroll_bar = true
 


### PR DESCRIPTION
This has been a tiny annoyance on macOS but a real problem on Plasma 6
as the bottom of the terminal was being hidden behind the panel at the
bottom of the screen.
