### PR TITLE
nixnuc: switch from simple-nixos-mailserver to postfix relay via hetznix01

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777743346,
-        "narHash": "sha256-gJ0aOSvmr1g06oSKGNDlIvfex7BVVxyP3txQ9gg2fdQ=",
+        "lastModified": 1779934676,
+        "narHash": "sha256-wp/K//HuAPN0TureyV342zjoee+vSq64+guX35X7DMU=",
         "owner": "genebean",
         "repo": "private-flake",
-        "rev": "8a0c1d3cf8a4eee614ac8c665dce70794de5f973",
+        "rev": "7ad20ffceb1b6e48af13b2207241441a2cafa97e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -180,7 +180,6 @@
           additionalModules = [
             inputs.cup-collector.nixosModules.default
             inputs.private-flake.nixosModules.private.nixnuc
-            inputs.simple-nixos-mailserver.nixosModule
           ];
         };
         # This machines is currently running Ubuntu and

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -68,25 +68,6 @@ in
     ];
   };
 
-  mailserver = {
-    enable = true;
-    enableImap = false;
-    enableImapSsl = false;
-    fqdn = "mail.${home_domain}";
-    domains = [
-      home_domain
-    ];
-    forwards = {
-      "${username}@localhost" = "${username}@technicalissues.us";
-      "root@localhost" = "root@technicalissues.us";
-      "root@${config.networking.hostName}" = "root@technicalissues.us";
-    };
-    stateVersion = 3;
-
-    # Use Let's Encrypt certificates from Nginx
-    certificateScheme = "acme";
-  };
-
   networking = {
     # Open ports in the firewall.
     firewall = {
@@ -326,7 +307,6 @@ in
         "${home_domain}" = {
           default = true;
           serverAliases = [
-            "mail.${home_domain}"
             "nix-tester.${home_domain}"
           ];
           listen = [


### PR DESCRIPTION
## Summary

- Removes `simple-nixos-mailserver` module from nixnuc's `additionalModules` — nixnuc does not receive external mail and does not need the full postfix + dovecot stack
- Drops the `mailserver` block and the `mail.home.technicalissues.us` nginx server alias from nixnuc's config
- Postfix relay config (relay host, aliases, TLS settings) lives in `private-flake` (already merged via genebean/private-flake#6)

Mail flows: nixnuc local submission → hetznix01 port 25 over Tailscale WireGuard → internet. No SASL credentials needed; hetznix01 trusts the Tailscale CGNAT range.

## Test plan

- [x] `nixdiff` on nixnuc evaluates cleanly
- [x] `nixup` on nixnuc applies without errors
- [x] `printf "Subject: relay test\n\ntest" | sendmail -v root` on nixnuc delivers to `root@technicalissues.us`

🤖 Generated with [Claude Code](https://claude.com/claude-code)