### PR TITLE
Replace Nominatim with self-hosted Photon for Dawarich geocoding

### DIFF
--- a/modules/hosts/nixos/hetznix01/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/default.nix
@@ -51,8 +51,8 @@ in
       enable = true;
       configureNginx = true;
       environment = {
-        NOMINATIM_API_HOST = "nominatim.home.technicalissues.us";
-        NOMINATIM_API_USE_HTTPS = "true";
+        PHOTON_API_HOST = "nixnuc.atlas-snares.ts.net:2322";
+        PHOTON_API_USE_HTTPS = "false";
       };
       extraEnvFiles = [
         "${config.sops.secrets.dawarich_env.path}"

--- a/modules/hosts/nixos/nixnuc/containers/photon.nix
+++ b/modules/hosts/nixos/nixnuc/containers/photon.nix
@@ -1,0 +1,28 @@
+{ config, ... }:
+let
+  volume_base = "/orico/photon";
+  http_port = "2322";
+in
+{
+  systemd.services."${config.virtualisation.oci-containers.containers.photon.serviceName}" = {
+    after = [ "zfs-create-orico-datasets.service" ];
+    wants = [ "zfs-create-orico-datasets.service" ];
+  };
+
+  virtualisation.oci-containers.containers = {
+    "photon" = {
+      autoStart = true;
+      image = "docker.io/rtuszik/photon-docker:latest";
+      environment = {
+        REGION = "planet";
+        UPDATE_STRATEGY = "PARALLEL";
+        UPDATE_INTERVAL = "30d";
+      };
+      ports = [ "${http_port}:2322" ];
+      volumes = [
+        "${volume_base}:/photon/data"
+      ];
+    };
+  };
+
+}

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -16,9 +16,11 @@ in
     ./hardware-configuration.nix
     ./containers/audiobookshelf.nix
     ./containers/mountain-mesh-bot-discord.nix
+    ./containers/photon.nix
     ./containers/psitransfer.nix
     ./cup-collector.nix
     ./monitoring-stack.nix
+    ./zfs-datasets.nix
     ../../../shared/nixos/lets-encrypt.nix
     ../../../shared/nixos/restic.nix
   ];
@@ -75,6 +77,7 @@ in
         22 # ssh
         80 # http to local Nginx
         443 # https to local Nginx
+        2322 # Photon geocoder in oci-container
         3000 # PsiTransfer in oci-container
         3001 # immich-kiosk in compose
         3002 # grafana
@@ -525,18 +528,6 @@ in
           acmeRoot = null;
           forceSSL = true;
         };
-        "nominatim.${home_domain}" = {
-          enableACME = true;
-          acmeRoot = null;
-          forceSSL = true;
-          extraConfig = ''
-            allow 127.0.0.1;
-            allow ::1;
-            allow 2600:1700:1712:880f:8eee:4ba4:75dc:f39c;
-            allow 100.64.0.0/10;
-            deny all;
-          '';
-        };
         "readit.${home_domain}" = {
           listen = [
             {
@@ -551,17 +542,6 @@ in
           locations."/".proxyPass = "http://${backend_ip}:8090";
         };
       };
-    };
-    nominatim = {
-      enable = true;
-      hostName = "nominatim.home.technicalissues.us";
-      settings = {
-        NOMINATIM_PROJECT_DIR = "/var/lib/nominatim/project";
-      };
-      ui.config = ''
-        Nominatim_Config.Page_Title="Beantown's Nominatim";
-        Nominatim_Config.Nominatim_API_Endpoint='https://${config.services.nominatim.hostName}/';
-      '';
     };
     pinchflat = {
       enable = true;
@@ -586,13 +566,6 @@ in
     postgresql = {
       enable = true;
       package = pkgs.postgresql_16;
-      ensureUsers = [
-        {
-          # Required by Nominatim
-          name = "www-data";
-          ensureDBOwnership = false;
-        }
-      ];
     };
     postgresqlBackup = {
       enable = true;

--- a/modules/hosts/nixos/nixnuc/zfs-datasets.nix
+++ b/modules/hosts/nixos/nixnuc/zfs-datasets.nix
@@ -1,0 +1,49 @@
+{ config, pkgs, ... }:
+{
+  systemd.services.zfs-create-orico-datasets = {
+    description = "Create orico ZFS datasets";
+    serviceConfig.Type = "oneshot";
+    wantedBy = [ "multi-user.target" ];
+    before = [
+      # Legacy ZFS mount units (datasets must exist before mount happens)
+      "var-lib-audiobookshelf.mount"
+      "var-lib-postgresql.mount"
+      "var-lib-postgresql-16-pg_wal.mount"
+      # NixOS services with orico state dirs
+      "forgejo.service"
+      "immich-server.service"
+      "jellyfin.service"
+      "nextcloud-setup.service"
+      "pinchflat.service"
+      "postgresql.service"
+    ]
+    # Dynamically include every OCI container's systemd service unit so new
+    # containers are automatically covered without editing this file.
+    # c.serviceName comes from virtualisation.oci-containers.containers.<name>.serviceName
+    # and resolves to e.g. "podman-photon" for a container named "photon".
+    ++ map (c: "${c.serviceName}.service") (
+      builtins.attrValues config.virtualisation.oci-containers.containers
+    );
+    after = [ "zfs-import-orico.service" ];
+    script =
+      let
+        zfs = "${pkgs.zfs}/bin/zfs";
+        datasets = [
+          "orico/audiobookshelf"
+          "orico/forgejo"
+          "orico/immich"
+          "orico/jellyfin"
+          "orico/mountain-mesh-bot-discord"
+          "orico/nextcloud"
+          "orico/photon"
+          "orico/pinchflat"
+          "orico/postgresql-data"
+          "orico/postgresql-wal-16"
+          "orico/psitransfer"
+        ];
+      in
+      builtins.concatStringsSep "\n" (
+        map (d: "${zfs} list ${d} >/dev/null 2>&1 || ${zfs} create -p ${d}") datasets
+      );
+  };
+}


### PR DESCRIPTION
## Summary

- Add `photon.nix` OCI container on nixnuc using `rtuszik/photon-docker` (planet index stored on the `/orico` ZFS dataset)
- Open port 2322 in nixnuc's main firewall allowlist (LAN + Tailscale access)
- Remove `services.nominatim`, its nginx vhost, and the `www-data` PostgreSQL user from nixnuc
- Switch Dawarich on hetznix01 from `NOMINATIM_API_HOST` to `PHOTON_API_HOST = "nixnuc.atlas-snares.ts.net:2322"`
- Add `zfs-datasets.nix` oneshot service that ensures all orico datasets exist before services start — new containers no longer require a manual `zfs create` before `nixup`

Note: Nominatim has already been manually stopped, its database dropped, and the Photon container is running on nixnuc.

## Test plan

- [ ] Apply on hetznix01 — Dawarich env vars updated
- [ ] Watch `podman logs -f photon` on nixnuc — planet index download will take a while (~90 GB)
- [ ] Once download completes, trigger reverse geocoding in Dawarich and confirm results populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)