### PR TITLE
Suppress Podman BoltDB deprecation warning in photon container

### DIFF
--- a/modules/hosts/nixos/nixnuc/containers/photon.nix
+++ b/modules/hosts/nixos/nixnuc/containers/photon.nix
@@ -15,6 +15,7 @@ in
       image = "docker.io/rtuszik/photon-docker:latest";
       environment = {
         REGION = "planet";
+        SUPPRESS_BOLTDB_WARNING = "1";
         UPDATE_STRATEGY = "PARALLEL";
         UPDATE_INTERVAL = "30d";
       };


### PR DESCRIPTION
## Summary

- Add `SUPPRESS_BOLTDB_WARNING=1` to the photon container environment to silence the noisy BoltDB deprecation warning in podman logs

## Test plan

- [ ] Apply on nixnuc
- [ ] Confirm BoltDB warning no longer appears in `journalctl -u podman-photon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)