### PR TITLE
Replace hardcoded tailnet name and WiFi SSIDs with private-flake options

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -740,11 +740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779934676,
-        "narHash": "sha256-wp/K//HuAPN0TureyV342zjoee+vSq64+guX35X7DMU=",
+        "lastModified": 1780005533,
+        "narHash": "sha256-6JsTRjhMgaFZTOuJDVmqys/nEKez6Ud/jOU3LoqfCw4=",
         "owner": "genebean",
         "repo": "private-flake",
-        "rev": "7ad20ffceb1b6e48af13b2207241441a2cafa97e",
+        "rev": "aeba0ca58ef1280b311f1a1d12fc6e389ac9fefb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -161,12 +161,16 @@
         kiosk-entryway = localLib.mkNixosHost {
           # Lenovo IdeaCentre Q190
           hostname = "kiosk-entryway";
+          additionalModules = [
+            inputs.private-flake.nixosModules.private.kiosk
+          ];
         };
         kiosk-gene-desk = localLib.mkNixosHost {
           system = "aarch64-linux";
           hostname = "kiosk-gene-desk";
           additionalModules = [
             inputs.nixos-hardware.nixosModules.raspberry-pi-4
+            inputs.private-flake.nixosModules.private.kiosk
           ];
         };
         nixnas1 = localLib.mkNixosHost {

--- a/modules/hosts/nixos/hetznix01/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/default.nix
@@ -51,7 +51,7 @@ in
       enable = true;
       configureNginx = true;
       environment = {
-        PHOTON_API_HOST = "nixnuc.atlas-snares.ts.net:2322";
+        PHOTON_API_HOST = "nixnuc.${config.private-flake.tailnetDomain}:2322";
         PHOTON_API_USE_HTTPS = "false";
       };
       extraEnvFiles = [

--- a/modules/hosts/nixos/hetznix01/post-install/mosquitto.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/mosquitto.nix
@@ -51,7 +51,7 @@ in
       homeassistant = {
         addresses = [
           {
-            address = "homeasistant-lc.atlas-snares.ts.net";
+            address = "homeasistant-lc.${config.private-flake.tailnetDomain}";
             port = 1883;
           }
         ];

--- a/modules/hosts/nixos/hetznix01/post-install/nginx.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/nginx.nix
@@ -3,7 +3,7 @@ let
   domain = "technicalissues.us";
   http_port = 80;
   https_port = 443;
-  private_btc = "umbrel.atlas-snares.ts.net";
+  private_btc = "umbrel.${config.private-flake.tailnetDomain}";
 in
 {
 

--- a/modules/hosts/nixos/kiosk-entryway/default.nix
+++ b/modules/hosts/nixos/kiosk-entryway/default.nix
@@ -45,13 +45,6 @@
     useNetworkd = true;
     wireless = {
       enable = true;
-      networks = {
-        # Home
-        "Diagon Alley".pskRaw = "ext:psk_diagon_alley";
-        # Public networks
-        "Gallery Row-GuestWiFi" = { };
-        "LocalTies Guest".pskRaw = "ext:psk_local_ties";
-      };
       secretsFile = "${config.sops.secrets.wifi_creds.path}";
     };
   };

--- a/modules/hosts/nixos/kiosk-gene-desk/default.nix
+++ b/modules/hosts/nixos/kiosk-gene-desk/default.nix
@@ -39,13 +39,6 @@
     useNetworkd = true;
     wireless = {
       enable = true;
-      networks = {
-        # Home
-        "Diagon Alley".pskRaw = "ext:psk_diagon_alley";
-        # Public networks
-        "Gallery Row-GuestWiFi" = { };
-        "LocalTies Guest".pskRaw = "ext:psk_local_ties";
-      };
       secretsFile = "${config.sops.secrets.wifi_creds.path}";
     };
   };


### PR DESCRIPTION
Tailnet name (atlas-snares.ts.net) is now sourced from config.private-flake.tailnetDomain, defined in private-flake's shared/tailnet.nix and imported by the hetznix01 and nixnuc modules.

WiFi SSIDs for kiosk-* hosts are now set by private-flake's shared/kiosk.nix via nixosModules.private.kiosk; the hardcoded network blocks are removed from the kiosk dots configs.