### PR TITLE
Extend dots.ports module to remaining NixOS hosts

### DIFF
--- a/modules/hosts/nixos/bigboy/default.nix
+++ b/modules/hosts/nixos/bigboy/default.nix
@@ -17,6 +17,7 @@ in
     # Include the results of the hardware scan.
     ./hardware-configuration.nix
     ../../../shared/linux/flatpaks.nix
+    ../../../shared/nixos/ports.nix
     ../../../shared/nixos/ripping.nix
   ];
 

--- a/modules/hosts/nixos/hetznix02/default.nix
+++ b/modules/hosts/nixos/hetznix02/default.nix
@@ -1,5 +1,7 @@
 {
+  config,
   inputs,
+  lib,
   pkgs,
   username,
   ...
@@ -7,6 +9,7 @@
 {
   imports = [
     ../../../shared/nixos/nixroutes.nix
+    ../../../shared/nixos/ports.nix
     ./disk-config.nix
     ./hardware-configuration.nix
     ./post-install
@@ -33,15 +36,18 @@
   ];
 
   networking = {
-    # Open ports in the firewall.
-    firewall.allowedTCPPorts = [
-      22 # ssh
-      80 # Nginx
-      443 # Nginx
-    ];
-    # firewall.allowedUDPPorts = [ ... ];
-    # Or disable the firewall altogether.
-    # firewall.enable = false;
+    firewall = {
+      allowedTCPPorts = lib.pipe config.dots.ports [
+        builtins.attrValues
+        (builtins.filter (e: e.openFirewall && e.protocol == "tcp"))
+        (map (e: e.port))
+      ];
+      allowedUDPPorts = lib.pipe config.dots.ports [
+        builtins.attrValues
+        (builtins.filter (e: e.openFirewall && e.protocol == "udp"))
+        (map (e: e.port))
+      ];
+    };
 
     hostId = "89bbb3e6"; # head -c4 /dev/urandom | od -A none -t x4
 

--- a/modules/hosts/nixos/hetznix02/post-install/monitoring.nix
+++ b/modules/hosts/nixos/hetznix02/post-install/monitoring.nix
@@ -16,7 +16,7 @@ in
           {
             job_name = "node";
             static_configs = [
-              { targets = [ "127.0.0.1:9100" ]; }
+              { targets = [ "127.0.0.1:${toString config.dots.ports.node-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -37,7 +37,7 @@ in
           {
             job_name = "nginx";
             static_configs = [
-              { targets = [ "127.0.0.1:9113" ]; }
+              { targets = [ "127.0.0.1:${toString config.dots.ports.nginx-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -84,7 +84,7 @@ in
     prometheus.exporters.node = {
       enable = true;
       listenAddress = "127.0.0.1";
-      port = 9100;
+      inherit (config.dots.ports.node-exporter) port;
       enabledCollectors = [
         "systemd"
       ];
@@ -98,7 +98,7 @@ in
     prometheus.exporters.nginx = {
       enable = true;
       listenAddress = "127.0.0.1";
-      port = 9113;
+      inherit (config.dots.ports.nginx-exporter) port;
       scrapeUri = "https://127.0.0.1/server_status";
       sslVerify = false;
     };

--- a/modules/hosts/nixos/kiosk-entryway/default.nix
+++ b/modules/hosts/nixos/kiosk-entryway/default.nix
@@ -7,6 +7,7 @@
 }:
 {
   imports = [
+    ../../../shared/nixos/ports.nix
     ./disk-config.nix
     ./hardware-configuration.nix
     ./monitoring.nix

--- a/modules/hosts/nixos/kiosk-entryway/monitoring.nix
+++ b/modules/hosts/nixos/kiosk-entryway/monitoring.nix
@@ -16,7 +16,7 @@ in
           {
             job_name = "node";
             static_configs = [
-              { targets = [ "127.0.0.1:9100" ]; }
+              { targets = [ "127.0.0.1:${toString config.dots.ports.node-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -63,7 +63,7 @@ in
     prometheus.exporters.node = {
       enable = true;
       listenAddress = "127.0.0.1";
-      port = 9100;
+      inherit (config.dots.ports.node-exporter) port;
       extraFlags = [
         "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|run|tmp|var/lib/docker/.+)($|/)"
         "--collector.diskstats.device-exclude=^(loop|ram|fd|sr|dm-|nvme[0-9]n[0-9]p[0-9]+_crypt)$"

--- a/modules/hosts/nixos/kiosk-gene-desk/default.nix
+++ b/modules/hosts/nixos/kiosk-gene-desk/default.nix
@@ -10,6 +10,7 @@
   imports = [
     # SD card image
     "${inputs.nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+    ../../../shared/nixos/ports.nix
     ./read-only-root.nix
   ];
 
@@ -92,6 +93,7 @@
       };
     prometheus.exporters.node = {
       enable = true;
+      inherit (config.dots.ports.node-exporter) port;
       enabledCollectors = [
         "logind"
         "systemd"

--- a/modules/hosts/nixos/rainbow-planet/default.nix
+++ b/modules/hosts/nixos/rainbow-planet/default.nix
@@ -9,6 +9,7 @@
   imports = [
     ./hardware-configuration.nix
     ../../../shared/linux/flatpaks.nix
+    ../../../shared/nixos/ports.nix
     ../../../shared/nixos/ripping.nix
   ];
 


### PR DESCRIPTION
## Summary
- **hetznix02**: import shared ports module, replace hardcoded `allowedTCPPorts` list with `lib.pipe`-derived firewall (22/80/443 come from shared), wire `node-exporter` and `nginx-exporter` port references in `monitoring.nix`
- **kiosk-entryway**: import shared ports module, wire `node-exporter` port in `monitoring.nix`
- **kiosk-gene-desk**: import shared ports module, make `node-exporter` port explicit via `inherit`
- **bigboy**, **rainbow-planet**: import shared ports module for consistency; no service ports to wire

## Test plan
- [ ] `nixos-rebuild dry-activate` on hetznix02 — verify firewall still opens 22/80/443
- [ ] `nixos-rebuild dry-activate` on kiosk-entryway and kiosk-gene-desk
- [ ] Confirm node-exporter and nginx-exporter still scrape correctly on hetznix02

🤖 Generated with [Claude Code](https://claude.com/claude-code)