### PR TITLE
chore: add Renovate config and pin OCI container images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "America/New_York",
+  "schedule": ["before 6am on thursday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates into a single PR",
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": "Group OCI container image updates into a single PR",
+      "groupName": "OCI container images",
+      "matchManagers": ["custom.regex"]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track OCI container image versions in NixOS container definitions",
+      "managerFilePatterns": [
+        "/^modules/hosts/nixos/.*containers/.*\\.nix$/"
+      ],
+      "matchStrings": ["image = \"(?<depName>[^\"]+):(?<currentValue>[^\"\\s]+)\""],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/modules/hosts/nixos/nixnuc/containers/photon.nix
+++ b/modules/hosts/nixos/nixnuc/containers/photon.nix
@@ -11,7 +11,7 @@ in
   virtualisation.oci-containers.containers = {
     "photon" = {
       autoStart = true;
-      image = "docker.io/rtuszik/photon-docker:latest";
+      image = "docker.io/rtuszik/photon-docker:2.3.0";
       environment = {
         REGION = "planet";
         SUPPRESS_BOLTDB_WARNING = "1";

--- a/modules/hosts/nixos/nixnuc/containers/psitransfer.nix
+++ b/modules/hosts/nixos/nixnuc/containers/psitransfer.nix
@@ -21,7 +21,7 @@ in
   virtualisation.oci-containers.containers = {
     "psitransfer" = {
       autoStart = true;
-      image = "psitrax/psitransfer";
+      image = "psitrax/psitransfer:v2.4.4";
       environmentFiles = [ psitransfer_dot_env ];
       ports = [ "${toString config.dots.ports.psitransfer.port}:3000" ];
       volumes = [


### PR DESCRIPTION
## Summary

- Adds `.github/renovate.json` with Thursday schedule (dots consumes repos updated Monday), GitHub Actions grouping rule, and a regex customManager to track OCI container image versions in NixOS container definitions
- Pins `photon` to `2.3.0` and `psitransfer` to `v2.4.4` so Renovate can track them (untagged/`latest` images are opaque to Renovate)

## Test plan

- [ ] Renovate opens PRs for container image updates going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)