### PR TITLE
chore: add Renovate config, pin OCI images, and use reusable flake-lock workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -2,25 +2,9 @@ name: Update flake.lock
 
 on:
   schedule:
-    # Weekly on Thursday at 06:00 UTC — keeps inputs fresh without noise
     - cron: "0 6 * * 4"
   workflow_dispatch:
 
 jobs:
   update:
-    name: bump flake.lock
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
-      - uses: DeterminateSystems/update-flake-lock@v28
-        with:
-          pr-title: "chore: update flake.lock"
-          pr-labels: "dependencies,nix"
-          commit-msg: "chore: update flake.lock"
-          # Sign commits so they pass any branch-protection signature requirements
-          sign-commits: true
+    uses: genebean/.github/.github/workflows/update-flake-lock.yml@main


### PR DESCRIPTION
## Summary

- Adds `.github/renovate.json` with GitHub Actions and OCI container image grouping rules (Thursday schedule — dots consumes other repos as flake inputs and should update after their Monday runs)
- Pins two OCI container images from floating `:latest` to specific versions
- Converts `update-flake-lock.yml` to call the shared reusable workflow from `genebean/.github`

## Test plan

- [ ] Verify `update-flake-lock` workflow runs correctly on next Thursday trigger or manual dispatch