### PR TITLE
feat(nixnuc): rate-limit ytdlfin /health endpoint in nginx

### DIFF
--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -289,6 +289,11 @@ in
             https   "max-age=31536000;";
         }
         add_header Strict-Transport-Security $hsts_header;
+
+        # Rate-limit the ytdlfin health endpoint so unauthenticated bots
+        # can't hammer it.  Uptime Kuma polls once per minute; 6r/m gives
+        # comfortable headroom while still blocking floods.
+        limit_req_zone $binary_remote_addr zone=ytdlfin_health:1m rate=6r/m;
       '';
       virtualHosts = {
         "${home_domain}" = {
@@ -537,6 +542,12 @@ in
           acmeRoot = null;
           forceSSL = true;
           locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.ytdlfin.port}";
+          locations."= /health" = {
+            proxyPass = "http://${backend_ip}:${toString config.dots.ports.ytdlfin.port}";
+            extraConfig = ''
+              limit_req zone=ytdlfin_health burst=3 nodelay;
+            '';
+          };
         };
       };
     };


### PR DESCRIPTION
## Summary

- Adds `limit_req_zone $binary_remote_addr zone=ytdlfin_health:1m rate=6r/m;` to `appendHttpConfig` so the zone is declared in the `http {}` block
- Adds `location = /health` to the ytdlfin virtual host with `limit_req zone=ytdlfin_health burst=3 nodelay;` — allows short bursts while capping sustained unauthenticated traffic at 6 requests/min per IP
- Companion to the ytdlfin `feat/health-endpoint` PR which adds the actual `/health` endpoint

## Test plan

- [x] `nixos-rebuild` applies cleanly on nixnuc
- [x] `curl https://ytdlfin.<domain>/health` returns `200 {"status":"ok"}`
- [x] Rapid repeated curls beyond the burst limit receive `503` from nginx
- [x] Uptime Kuma monitor on `/health` stays green at its normal poll interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)