### PR TITLE
feat(nixnuc): add claude-code and Samba share for jellyfin staging

### DIFF
--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -47,6 +47,7 @@ in
       LIBVA_DRIVER_NAME = "iHD";
     };
     systemPackages = with pkgs; [
+      claude-code
       inputs.compose2nix.packages.${pkgs.stdenv.hostPlatform.system}.default
       docker-compose
       intel-gpu-tools

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -602,6 +602,31 @@ in
         Persistent = true;
       };
     };
+    samba = {
+      enable = true;
+      settings = {
+        global = {
+          "workgroup" = "BEANTOWN";
+          "server string" = "nixnuc";
+          "server role" = "standalone server";
+          "map to guest" = "never";
+          "hosts allow" = "192.168.20.0/22 100.64.0.0/10 127.0.0.1";
+          "hosts deny" = "0.0.0.0/0";
+          "unix password sync" = "yes";
+          "pam password change" = "yes";
+          "passwd program" = "/run/wrappers/bin/passwd %u";
+        };
+        "jellyfin-staging" = {
+          path = "/orico/jellyfin/staging";
+          "read only" = "no";
+          "guest ok" = "no";
+          "browseable" = "yes";
+          "valid users" = username;
+          "create mask" = "0644";
+          "directory mask" = "0755";
+        };
+      };
+    };
     smartd.enable = true;
     tailscale = {
       enable = true;

--- a/modules/hosts/nixos/nixnuc/ports.nix
+++ b/modules/hosts/nixos/nixnuc/ports.nix
@@ -1,3 +1,4 @@
+# Entries within each section are sorted by port number in ascending order.
 {
   config.dots.ports = {
     # Override global photon default: open the firewall on this host
@@ -6,6 +7,14 @@
     };
 
     # Firewalled TCP services
+    smb-netbios-session = {
+      port = 139;
+      openFirewall = true;
+    };
+    smb = {
+      port = 445;
+      openFirewall = true;
+    };
     psitransfer = {
       port = 3000;
       openFirewall = true;
@@ -42,20 +51,20 @@
       port = 8001;
       openFirewall = true;
     };
-    syncthing-gui = {
-      port = 8384;
-      openFirewall = true;
-    };
-    atuin = {
-      port = 8888;
-      openFirewall = true;
-    };
     wallabag = {
       port = 8090;
       openFirewall = true;
     };
     pocketbase = {
       port = 8091;
+      openFirewall = true;
+    };
+    syncthing-gui = {
+      port = 8384;
+      openFirewall = true;
+    };
+    atuin = {
+      port = 8888;
       openFirewall = true;
     };
     pinchflat = {
@@ -80,17 +89,27 @@
     cadvisor = {
       port = 8081;
     };
-    victoriametrics = {
-      port = 8428;
-    };
     jellyfin = {
       port = 8096;
+    };
+    victoriametrics = {
+      port = 8428;
     };
     mealie = {
       port = 9000;
     };
 
     # UDP services
+    smb-netbios-ns = {
+      port = 137;
+      protocol = "udp";
+      openFirewall = true;
+    };
+    smb-netbios-dgram = {
+      port = 138;
+      protocol = "udp";
+      openFirewall = true;
+    };
     jellyfin-ssdp = {
       port = 1900;
       protocol = "udp";


### PR DESCRIPTION
## Summary

- Adds `claude-code` to nixnuc's system packages
- Adds an authenticated Samba share exposing `/orico/jellyfin/staging` for managing media from other machines on the LAN and via Tailscale
  - Workgroup: `BEANTOWN`
  - No guest access; valid users restricted to `gene`
  - Read/write with `unix password sync` so the Samba password stays in sync with the system password after initial setup (`sudo smbpasswd -a gene`)
  - Access restricted to LAN (`192.168.20.0/22`) and Tailscale (`100.64.0.0/10`)
  - Opens firewall ports 445/tcp, 139/tcp, 137/udp, 138/udp

## Test plan

- [x] `nixdiff` reviewed before applying
- [x] `nixup` applied cleanly (second run resolved transient dbus-broker reload)
- [x] `samba-smbd` and `samba-nmbd` confirmed active and running
- [x] Share mounted and verified working from another machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)