### PR TITLE
chore(hetznix01): ClickHouse TTLs, orphaned log cleanup, flake update, claude-code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781981105,
-        "narHash": "sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg+TNl0CjxS3UQJKlw=",
+        "lastModified": 1783221248,
+        "narHash": "sha256-ESQnuNHEDChsB4IxoLRhscVahqkDWkTb+qdIz8euYt4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7bfff44b465909f69a442701293bc0badcf476dc",
+        "rev": "af2beae5f0fae0a4310cc0e6aef2572f56090353",
         "type": "github"
       },
       "original": {
@@ -453,11 +453,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782191243,
-        "narHash": "sha256-igCpUcCaYSjT6LUj6n1M5O0SFhfcMFCtfFsW7yMazyE=",
+        "lastModified": 1782962333,
+        "narHash": "sha256-3uQHlsljEgAqermVRTNSgk+YKnIxnIEMammX4jYfoTc=",
         "owner": "numtide",
         "repo": "nix-auth",
-        "rev": "e0b7e0c3aea2470e230bb36f5e8546885f93e5b4",
+        "rev": "606cf8a61467a1c2ca208e7c9698c05b0a4631e9",
         "type": "github"
       },
       "original": {
@@ -489,11 +489,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1780908363,
-        "narHash": "sha256-llGS4y3Qh1eUkli3/Y2VY9FV3GOUKFZR1E2BDftt45Q=",
+        "lastModified": 1783368811,
+        "narHash": "sha256-0H8jDwR4Kegb3heaTrH1ftbgKfZVDT8JE+46uXxDy/Q=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "1df08625f0f8c7d6e300a0e5df7955bbb877d809",
+        "rev": "20d42f0ee98c9fe9f85e8d1de474f1409ed10d05",
         "type": "github"
       },
       "original": {
@@ -610,11 +610,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1782562157,
-        "narHash": "sha256-a7+T6QSeowynwZ1ZJJbP8T8ntAytvrui8kFGJmIZt2c=",
+        "lastModified": 1783370751,
+        "narHash": "sha256-E+3MIMvKuo9k+K+qLQ9YXzsBzkgHuyVLnsEbN2DFfuc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a9cf7546a938c737b079e738de73934a13de9784",
+        "rev": "662bd6e312d2c8b212e32cb377abaee190749320",
         "type": "github"
       },
       "original": {
@@ -642,11 +642,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -657,11 +657,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1782175435,
-        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -702,11 +702,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1782375420,
-        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
@@ -776,15 +776,15 @@
       "locked": {
         "lastModified": 1782355444,
         "narHash": "sha256-k0Lx2KkxNlL8CKuJF/tJpszRCG50IscHM2tiWQBWDAg=",
-        "ref": "refs/heads/main",
+        "owner": "genebean",
+        "repo": "private-flake",
         "rev": "19444ba02f1bf82d59c0ad342ef8159975beda4d",
-        "revCount": 24,
-        "type": "git",
-        "url": "ssh://git@github.com/genebean/private-flake"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "ssh://git@github.com/genebean/private-flake"
+        "owner": "genebean",
+        "repo": "private-flake",
+        "type": "github"
       }
     },
     "root": {
@@ -899,11 +899,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782165805,
-        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {
@@ -1043,11 +1043,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782611500,
-        "narHash": "sha256-r9EGFeCKrrP1O9gdVpyaqipcUXl7R2QIc8f9xGs4khY=",
+        "lastModified": 1783476436,
+        "narHash": "sha256-i0EmoRcuhvH4sxYQZMrggm0dtmpn6suw9ijkFNRMifg=",
         "owner": "genebean",
         "repo": "ytdlfin",
-        "rev": "e338ddb563f70503a487289290ccfdbd81487b48",
+        "rev": "555475f436353721145b122c9b287c3d77517247",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,7 @@
 
     # Private flake for sensitive configs
     private-flake = {
-      url = "git+ssh://git@github.com/genebean/private-flake";
+      url = "github:genebean/private-flake";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         simple-nixos-mailserver.follows = "simple-nixos-mailserver";

--- a/modules/hosts/nixos/default.nix
+++ b/modules/hosts/nixos/default.nix
@@ -16,6 +16,7 @@
     ];
     systemPackages = with pkgs; [
       age
+      claude-code
       dconf2nix
       file
       iftop

--- a/modules/hosts/nixos/hetznix01/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/default.nix
@@ -21,6 +21,16 @@ in
   ];
 
   services = {
+    clickhouse.serverConfig = {
+      # pulled in by plausible
+      trace_log.ttl = "event_date + INTERVAL 14 DAY DELETE";
+      metric_log.ttl = "event_date + INTERVAL 14 DAY DELETE";
+      asynchronous_metric_log.ttl = "event_date + INTERVAL 14 DAY DELETE";
+      part_log.ttl = "event_date + INTERVAL 30 DAY DELETE";
+      query_log.ttl = "event_date + INTERVAL 30 DAY DELETE";
+      query_thread_log.ttl = "event_date + INTERVAL 30 DAY DELETE";
+      text_log.ttl = "event_date + INTERVAL 14 DAY DELETE";
+    };
     collabora-online = {
       enable = true;
       inherit (config.dots.ports.collabora) port;
@@ -183,37 +193,62 @@ in
     };
   };
 
-  systemd.services = {
-    nextcloud-config-collabora =
-      let
-        inherit (config.services.nextcloud) occ;
-
-        wopi_url = "http://[::1]:${toString config.services.collabora-online.port}";
-        public_wopi_url = "https://collabora.pack1828.org";
-        wopi_allowlist = lib.concatStringsSep "," [
-          "127.0.0.1"
-          "::1"
-          "5.161.244.95"
-          "2a01:4ff:f0:977c::1"
-        ];
-      in
-      {
-        wantedBy = [ "multi-user.target" ];
-        after = [
-          "nextcloud-setup.service"
-          "coolwsd.service"
-        ];
-        requires = [ "coolwsd.service" ];
+  systemd = {
+    services = {
+      clickhouse-drop-orphaned-logs = {
+        description = "Drop orphaned numbered ClickHouse system log tables";
+        after = [ "clickhouse.service" ];
+        requires = [ "clickhouse.service" ];
+        serviceConfig.Type = "oneshot";
         script = ''
-          ${occ}/bin/nextcloud-occ config:app:set richdocuments wopi_url --value ${lib.escapeShellArg wopi_url}
-          ${occ}/bin/nextcloud-occ config:app:set richdocuments public_wopi_url --value ${lib.escapeShellArg public_wopi_url}
-          ${occ}/bin/nextcloud-occ config:app:set richdocuments wopi_allowlist --value ${lib.escapeShellArg wopi_allowlist}
-          ${occ}/bin/nextcloud-occ richdocuments:setup
+          ${pkgs.clickhouse}/bin/clickhouse-client \
+            --query "SELECT concat('DROP TABLE IF EXISTS system.', name, ';') \
+                     FROM system.tables \
+                     WHERE database = 'system' \
+                     AND match(name, '^[a-z_]+_log_[0-9]+')" \
+            | ${pkgs.clickhouse}/bin/clickhouse-client --multiquery
         '';
-        serviceConfig = {
-          Type = "oneshot";
-        };
       };
+
+      nextcloud-config-collabora =
+        let
+          inherit (config.services.nextcloud) occ;
+
+          wopi_url = "http://[::1]:${toString config.services.collabora-online.port}";
+          public_wopi_url = "https://collabora.pack1828.org";
+          wopi_allowlist = lib.concatStringsSep "," [
+            "127.0.0.1"
+            "::1"
+            "5.161.244.95"
+            "2a01:4ff:f0:977c::1"
+          ];
+        in
+        {
+          wantedBy = [ "multi-user.target" ];
+          after = [
+            "nextcloud-setup.service"
+            "coolwsd.service"
+          ];
+          requires = [ "coolwsd.service" ];
+          script = ''
+            ${occ}/bin/nextcloud-occ config:app:set richdocuments wopi_url --value ${lib.escapeShellArg wopi_url}
+            ${occ}/bin/nextcloud-occ config:app:set richdocuments public_wopi_url --value ${lib.escapeShellArg public_wopi_url}
+            ${occ}/bin/nextcloud-occ config:app:set richdocuments wopi_allowlist --value ${lib.escapeShellArg wopi_allowlist}
+            ${occ}/bin/nextcloud-occ richdocuments:setup
+          '';
+          serviceConfig = {
+            Type = "oneshot";
+          };
+        };
+    };
+
+    timers.clickhouse-drop-orphaned-logs = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "monthly";
+        Persistent = true;
+      };
+    };
   };
 
   # Enable common container config files in /etc/containers

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -47,7 +47,6 @@ in
       LIBVA_DRIVER_NAME = "iHD";
     };
     systemPackages = with pkgs; [
-      claude-code
       inputs.compose2nix.packages.${pkgs.stdenv.hostPlatform.system}.default
       docker-compose
       intel-gpu-tools


### PR DESCRIPTION
## Summary

- **Flake update**: bump all inputs and switch `private-flake` from SSH to HTTPS GitHub URL
- **claude-code**: move from nixnuc-only to the shared NixOS module (available on all hosts)
- **ClickHouse maintenance** (hetznix01): add TTLs to all system log tables and a monthly cleanup timer for orphaned numbered tables

### Background

ClickHouse system log tables accumulated without TTLs and filled the root filesystem tonight. The two largest orphans (`trace_log_2` at 33 GiB, `trace_log_3` at 22 GiB) alone consumed ~55 GiB. All orphaned numbered tables have been dropped manually; this PR ensures they can't build up again.

### ClickHouse TTLs added

| Table | TTL |
|---|---|
| trace_log | 14 days |
| metric_log | 14 days |
| asynchronous_metric_log | 14 days |
| text_log | 14 days |
| part_log | 30 days |
| query_log | 30 days |
| query_thread_log | 30 days |

### Orphaned table cleanup

ClickHouse renames existing system log tables (appending `_0`, `_1`, etc.) each time it restarts after a schema change (e.g. a NixOS rebuild that modifies the TTL config). These copies have no TTL and accumulate indefinitely. A new monthly systemd timer runs:

```sql
SELECT concat('DROP TABLE IF EXISTS system.', name, ';')
FROM system.tables
WHERE database = 'system'
AND match(name, '^[a-z_]+_log_[0-9]+')
```
...and pipes the result back into `clickhouse-client --multiquery`.

## Test plan

- [x] TTLs verified live on hetznix01 via `SHOW CREATE TABLE system.<name>`
- [x] Orphaned numbered tables dropped manually (confirmed empty via `system.tables` query)
- [x] Plausible confirmed healthy (`systemctl status plausible` active, no errors since restart)
- [x] After `nixos-rebuild switch`, timer unit confirmed active: `clickhouse-drop-orphaned-logs.timer` is enabled and waiting, next run 2026-08-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)