### PR TITLE
chore(hetznix01): remove OwnTracks

### DIFF
--- a/modules/hosts/nixos/hetznix01/ports.nix
+++ b/modules/hosts/nixos/hetznix01/ports.nix
@@ -60,12 +60,6 @@
     matrix-synapse = {
       port = 8008;
     };
-    owntracks-frontend = {
-      port = 8082;
-    };
-    owntracks-recorder = {
-      port = 8083;
-    };
     plausible = {
       port = 8001;
     };

--- a/modules/hosts/nixos/hetznix01/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/default.nix
@@ -140,7 +140,6 @@ in
     };
     restic.backups.daily = {
       paths = [
-        "${config.users.users.${username}.home}/compose-files/owntracks"
         "/var/backup/postgresql"
         "/var/lib/uptime-kuma"
       ];
@@ -181,10 +180,6 @@ in
       matrix_homeserver_signing_key.owner = config.users.users.matrix-synapse.name;
       mqtt_recorder_pass.restartUnits = [ "mosquitto.service" ];
       nextcloud_admin_pass.owner = config.users.users.nextcloud.name;
-      owntracks_basic_auth = {
-        owner = config.users.users.nginx.name;
-        restartUnits = [ "nginx.service" ];
-      };
       plausible_admin_pass.owner = config.users.users.nginx.name;
       plausible_secret_key_base.owner = config.users.users.nginx.name;
       tailscale_key = {

--- a/modules/hosts/nixos/hetznix01/post-install/nginx.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/nginx.nix
@@ -191,51 +191,12 @@ in
         forceSSL = true;
         locations."/".return = "301 https://beanbag.technicalissues.us";
       };
-      "ot.${domain}" = {
-        enableACME = true;
-        acmeRoot = null;
-        forceSSL = true;
-        basicAuthFile = config.sops.secrets.owntracks_basic_auth.path;
-        # OwnTracks Frontend container
-        locations."/".proxyPass = "http://127.0.0.1:${toString config.dots.ports.owntracks-frontend.port}";
-      };
       "pack1828.org" = {
         enableACME = true;
         acmeRoot = null;
         forceSSL = true;
         locations."/" = {
           return = "307 https://cloud.pack1828.org";
-        };
-      };
-      "recorder.${domain}" = {
-        enableACME = true;
-        acmeRoot = null;
-        forceSSL = true;
-        basicAuthFile = config.sops.secrets.owntracks_basic_auth.path;
-        locations = {
-          # OwnTracks Recorder
-          "/" = {
-            proxyPass = "http://127.0.0.1:${toString config.dots.ports.owntracks-recorder.port}";
-          };
-          "/pub" = {
-            # Client apps need to point to this path
-            extraConfig = "proxy_set_header X-Limit-U $remote_user;";
-            proxyPass = "http://127.0.0.1:${toString config.dots.ports.owntracks-recorder.port}/pub";
-          };
-          "/static/" = {
-            proxyPass = "http://127.0.0.1:${toString config.dots.ports.owntracks-recorder.port}/static/";
-          };
-          "/utils/" = {
-            proxyPass = "http://127.0.0.1:${toString config.dots.ports.owntracks-recorder.port}/utils/";
-          };
-          "/view/" = {
-            extraConfig = "proxy_buffering off;";
-            proxyPass = "http://127.0.0.1:${toString config.dots.ports.owntracks-recorder.port}/view/";
-          };
-          "/ws" = {
-            extraConfig = "rewrite ^/(.*) /$1 break;";
-            proxyPass = "http://127.0.0.1:${toString config.dots.ports.owntracks-recorder.port}";
-          };
         };
       };
       "stats.${domain}" = {

--- a/modules/hosts/nixos/hetznix01/secrets.yaml
+++ b/modules/hosts/nixos/hetznix01/secrets.yaml
@@ -8,7 +8,6 @@ mosquitto_mountain_mesh: ENC[AES256_GCM,data:LczPsPtAgkTTGcG3KYXMkfeA67e81Q5zJ5N
 mosquitto_genebean: ENC[AES256_GCM,data:QzLpyXST+hlmCq7SIpkxra5jiA3JTWPgGV/NPBoeC+yESpiXQOnWzzSiNS09l3xGmjvTLR4dGUeTD1CUl4FwUsMT15MWjWHYNAfuoywy50i7xCCKPwERDxniar7Ykq7o0rz2UkNlW0X7uLQar+rn6g==,iv:ECt5oAh2R1a+RFEk5lEsDFEj2+4Z/D4Q7ezK1iTsS6k=,tag:4tLFjqezUFW8hA8udyPkiw==,type:str]
 mqtt_recorder_pass: ENC[AES256_GCM,data:N44nv2mk5zguWXNHdKsxhoKUjiduD1hzsAb6,iv:aLudKuUBTPXgtAF33exELH/PESD0CqoDaydeqdhcmbA=,tag:3lhrqO8jxJiRHWZjWSRa0g==,type:str]
 nextcloud_admin_pass: ENC[AES256_GCM,data:dite1z9lAQg4geuoDvXnveJP0iI/ouEe,iv:VT17WjQdS8T1qIxwyjdLy2VNpP5tv7KXhY+twpotiaQ=,tag:5DQLvRI87BamUutSUnvncA==,type:str]
-owntracks_basic_auth: ENC[AES256_GCM,data:GX1U1uf7+erE+g9GzhXK5ED2QicfcbpRCwpJDw6Zr9X2FtdMYleH5mhLxw==,iv:PflRq+P50+oFf4wv5wwlY6V9bApGuJ3tlYTvJZ5mg0E=,tag:VHBY5qv7rX74DGURsYaWpw==,type:str]
 pack1828_gene_liverman_pass: ENC[AES256_GCM,data:f1sO6ZKbg6wsPtAE0X5g0vqvEToBG4Ps+f0GiAK7ThDHna4UDHc0MlEbLsRb+C/WtKfDMFm2EfbfFIks,iv:jy7gt4mGXjsUXbuW8ml/tkc6AEOnkfflP7rtD6pU4JU=,tag:ccS0VfRd5yT/i+ic/N2Suw==,type:str]
 pack1828_dawn_liverman_pass: ENC[AES256_GCM,data:reJDYGed0VBGoZ48FMPhWFBn7zM42uFcMaBy2569JS4kKZ9AqFFVJKstmyj3U81hE7aG2hxaLOT0sGQA,iv:tfXu7jCuuAcR7kxVb8Lfj/tKhwpZ/gTY9xwmWOy/kPA=,tag:qHOdjvz8yGChumP5D7q25w==,type:str]
 pack1828_steve_mclendon_pass: ENC[AES256_GCM,data:js6im7Uobhgh8TM/R6pAQeBOWbqMmmVu+y+0yG/W0QRAtjxqy2gwYdtu0PBf7ZbXoDvqLWBj9tYiH5T2,iv:dmGmkNrkcWfGv/bgpf/TowDVb7sG3Oqq26iJqfMfE74=,tag:W7TmUvOM+ApkJ4EXDqmRLw==,type:str]
@@ -17,8 +16,7 @@ plausible_secret_key_base: ENC[AES256_GCM,data:6Co3VO9Ocmd6cppRpm763jjpRE9yCb75F
 tailscale_key: ENC[AES256_GCM,data:Bl00WuIrLvxmt7aNsoXC6G7XFls7waZMzdfo/MsEOZl/i3wHwrjrmgwd3V4GkaJ42UjrC1OLobrkuLves4w=,iv:tlCu0EWgvhvs1ANdtQr7KWHJ2RjpHniUm/rFC4L/MHs=,tag:+8eov9w+SPGZPnjMdrN8gA==,type:str]
 sops:
     age:
-        - recipient: age1rd55wsu0hhvxk25tm69d9h57z0z0u6556x4ypg09muj3vh4yqs5qaw23nu
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5ejVRcmRBR3p6N2V1anZp
             RkEwVTBWR09TazdNTnZ3YWlUUU9IOUordDNjClJmdU9sUkttaktTOTR4WldFWXFs
@@ -26,7 +24,8 @@ sops:
             WkI4ejBaODI0d0tjWHpTT3VWTXNyaXcKMDtvHN4gcZqBNslyC+NwYW05zgs8QuPV
             W6EktAz+xu6kx5BJbli5GkUFmj52AtEGIqZ1Sr4a0pKQACC87XcTQA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-26T04:52:54Z"
-    mac: ENC[AES256_GCM,data:1pDP/ENGdw+bp9euYeiq3V7FNg6/IO88mbBcaYoI+Zi2TCETmCJXGupMKPeyTQ+OJf9C5yHaBHcVISLyJbrDehLp4ndCvNxl0jboytub3YCn0s7QxOLmNI0guRO45EPpPKQekD9TTqv/8QxvKqTvfmIlpdb+Vfii2XTsY5fkNA0=,iv:n7UcVvOYVyvAu74IJUE506GboPTg7rOekgsgoyx8ig4=,tag:gkrV7H/OKAEldFbuD1VEfw==,type:str]
+          recipient: age1rd55wsu0hhvxk25tm69d9h57z0z0u6556x4ypg09muj3vh4yqs5qaw23nu
+    lastmodified: "2026-07-08T04:15:25Z"
+    mac: ENC[AES256_GCM,data:0NxHGl0CbBUTRejeECkx8yEGdg5V5NuM38h+pEUknwNIPXIWiGjF5T9rZHcojvQlp43hSYRhaokwAhlr9eHvlQKsW3fMvdqcRLyT3L5BuNdCojbdfS+N5ZSrmIHvD874SKVIFtGCSLYBlP7anTPs/MxhrvjY1jh7LJjBOTxP2Ro=,iv:rX7G8u3KQuCn4rs8RnmJh1v400dcAE+aqRhUHA489IM=,tag:YCh607YlhPORGiXWy/AmrQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.13.1


### PR DESCRIPTION
## Summary

- Remove nginx vhosts for `ot.technicalissues.us` and `recorder.technicalissues.us`
- Remove `owntracks-frontend` and `owntracks-recorder` port definitions
- Remove `owntracks_basic_auth` sops secret
- Remove OwnTracks compose backup path from restic

OwnTracks is unused. Containers were stopped, images pruned (freed 2.4 GB), and `~/compose-files/owntracks/` removed from disk prior to this PR.

## Test plan

- [x] `nixos-rebuild switch` applies cleanly
- [x] nginx reloads without errors
- [x] Zero failed units post-apply

## Post-merge cleanup

- ACME certs for `ot.technicalissues.us` and `recorder.technicalissues.us` exist in `/var/lib/acme/` and will stop renewing naturally — safe to delete manually whenever

🤖 Generated with [Claude Code](https://claude.com/claude-code)