### PR TITLE
fix(nixnuc): update ABS and migrate podman to SQLite backend

### DIFF
--- a/modules/hosts/nixos/nixnuc/containers/audiobookshelf.nix
+++ b/modules/hosts/nixos/nixnuc/containers/audiobookshelf.nix
@@ -8,7 +8,7 @@ in
   virtualisation.oci-containers.containers = {
     "audiobookshelf" = {
       autoStart = true;
-      image = "ghcr.io/advplyr/audiobookshelf:2.35.0";
+      image = "ghcr.io/advplyr/audiobookshelf:2.35.1";
       environment = {
         AUDIOBOOKSHELF_UID = "99";
         AUDIOBOOKSHELF_GID = "100";

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -742,7 +742,10 @@ in
 
   # Enable common container config files in /etc/containers
   virtualisation = {
-    containers.enable = true;
+    containers = {
+      enable = true;
+      containersConf.settings.engine.database_backend = "sqlite";
+    };
     oci-containers.backend = "podman";
     # Compose based apps were crashing with podman compose, so back to Docker...
     docker = {


### PR DESCRIPTION
## Summary

- Bumps Audiobookshelf from 2.35.0 to 2.35.1
- Migrates Podman's internal database from BoltDB to SQLite by setting
  `database_backend = "sqlite"` in containers.conf — BoltDB support is
  being removed in Podman 6.0

## Post-merge steps

After deploying, complete the Podman database migration:

```
sudo nixos-rebuild switch --flake .
sudo podman system migrate --migrate-db
```

Or simply reboot after rebuilding — Podman will migrate automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)