### PR TITLE
feat: add Ghostty via genebean module namespace, plasma-manager, and omp theme update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ read-only lookups or when self-hosting is genuinely impractical.
 flake.nix                    — inputs, outputs, host wiring
 lib/                         — mkNixosHost / mkDarwinHost / mkHomeConfig helpers
 modules/
+  genebean/                  — reusable namespaced modules (see genebean Module Pattern below)
+    home/                    — home-manager modules; options live under genebean.*
+    darwin/                  — nix-darwin companion modules (e.g. Homebrew cask wiring)
   hosts/                     - host-specific modules
     nixos/<hostname>/        — per-host NixOS config + hardware + secrets.yaml
     darwin/<hostname>/       — per-host nix-darwin config
@@ -224,6 +227,99 @@ inherit (config.dots.ports.grafana) port;
 When adding a service that other hosts need to know about (e.g. a shared API
 endpoint referenced across hosts), declare it in the shared registry. When
 adding a service local to one host, declare it in that host's `ports.nix`.
+
+---
+
+## genebean Module Pattern
+
+`modules/genebean/` holds reusable, option-driven modules namespaced under
+`genebean.*`. This is the home for any config that needs to behave differently
+across platforms (NixOS / macOS / Ubuntu) without requiring `lib.mkForce` at
+the call site.
+
+### Structure
+
+```
+modules/genebean/
+  home/
+    default.nix    — imports all home-manager modules in this directory
+    ghostty.nix    — example: genebean.ghostty options
+  darwin/
+    default.nix    — imports all nix-darwin companion modules
+    ghostty.nix    — example: drives homebrew.casks from the home-manager option
+```
+
+Each directory's `default.nix` is an `{ imports = [ ... ]; }` list. **Adding a
+new module means creating the file and adding one line to `default.nix` — the
+flake output and all lib consumers stay unchanged.**
+
+### Flake outputs and consumption
+
+Both directories are exposed as flake outputs pointing at the directory (not
+individual files):
+
+```nix
+homeManagerModules.genebean = ./modules/genebean/home;
+darwinModules.genebean      = ./modules/genebean/darwin;
+```
+
+All three lib helpers (`mkNixosHost`, `mkDarwinHost`, `mkHomeConfig`) import
+`inputs.self.homeManagerModules.genebean` into the home-manager module list.
+`mkDarwinHost` additionally imports `inputs.self.darwinModules.genebean` as a
+nix-darwin system module.
+
+Consumers set options — they never import module files directly.
+
+### Platform detection
+
+`genebeanLib` is an attrset defined in `lib/default.nix` and passed as
+`extraSpecialArgs` by all three lib helpers. Use it inside any home-manager
+module instead of raw builtins:
+
+```nix
+{ genebeanLib, lib, pkgs, ... }:
+```
+
+Current helpers:
+
+| Helper | Value | Use for |
+|---|---|---|
+| `genebeanLib.isNixOS` | `true` in `mkNixosHost`, `false` elsewhere | NixOS vs other Linux |
+| `pkgs.stdenv.isDarwin` | stdlib | macOS detection (no lib wrapper needed) |
+
+`genebeanLib.isNixOS` is set explicitly by each builder rather than probed at
+evaluation time — `mkNixosHost` overrides it to `true` via
+`genebeanLib // { isNixOS = true; }` in `extraSpecialArgs`; `mkDarwinHost` and
+`mkHomeConfig` pass the base `genebeanLib` which defaults `isNixOS` to `false`.
+This avoids the impure `builtins.pathExists /etc/NIXOS` probe, which is
+unreliable in flake pure-eval mode and when building for a remote target.
+
+Options that vary by platform should use these as their `default`, so no
+host-level overrides are needed:
+
+```nix
+installViaNix = lib.mkOption {
+  type    = lib.types.bool;
+  default = genebeanLib.isNixOS;
+};
+```
+
+### Darwin companion modules
+
+When a feature requires a nix-darwin system-level action (e.g. adding a
+Homebrew cask), create a companion module under `modules/genebean/darwin/`.
+The companion reads the home-manager option via
+`config.home-manager.users.${username}.genebean.<module>.<option>` and acts on
+it — the consumer only ever sets the home-manager option. `username` is
+available as a specialArg in all darwin system modules.
+
+### Adding a new genebean module
+
+1. Create `modules/genebean/home/<name>.nix` — define `options.genebean.<name>`
+   and `config = lib.mkIf cfg.enable { ... }`
+2. Add `./name.nix` to `modules/genebean/home/default.nix`
+3. If a darwin system action is needed, repeat for `modules/genebean/darwin/`
+4. Set options at the call site (`all-gui.nix`, a host file, etc.) — no imports
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ This repo is a Nix flake that manages most of my setup on macOS and fully manage
   - `mkNixosHost` - constructs NixOS system configurations
   - `mkDarwinHost` - constructs nix-darwin system configurations
   - `mkHomeConfig` - constructs Home Manager configurations
+  - `genebeanLib` - shared platform-detection helpers passed to all modules via `extraSpecialArgs`
 - `modules/` contains Nix modules organized by type:
+  - `modules/genebean/` - reusable, option-driven modules under the `genebean.*` namespace
+    - `modules/genebean/home/` - Home Manager modules; exposed as `homeManagerModules.genebean`
+    - `modules/genebean/darwin/` - nix-darwin companion modules; exposed as `darwinModules.genebean`
   - `modules/shared/` - shared modules imported by multiple hosts
     - `modules/shared/home/general/` - Home Manager config for all GUI users
     - `modules/shared/home/linux/` - Home Manager config for Linux-specific apps

--- a/flake.lock
+++ b/flake.lock
@@ -738,6 +738,29 @@
         "type": "github"
       }
     },
+    "plasma-manager": {
+      "inputs": {
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783574839,
+        "narHash": "sha256-ICof1tV4/9XheBLBGf7dhMhfMq4dOs1zwTHrr7zGFlA=",
+        "owner": "nix-community",
+        "repo": "plasma-manager",
+        "rev": "c551f0687658e4bb699cfff6015436ad7ee57a0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "plasma-manager",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -805,6 +828,7 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_4",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "plasma-manager": "plasma-manager",
         "private-flake": "private-flake",
         "simple-nixos-mailserver": "simple-nixos-mailserver",
         "sops-nix": "sops-nix",

--- a/flake.lock
+++ b/flake.lock
@@ -340,11 +340,11 @@
     "genebean-omp-themes": {
       "flake": false,
       "locked": {
-        "lastModified": 1775590646,
-        "narHash": "sha256-0kr+6Kgb6W6aRYXewqna+Qpq7PF7g5wq7rwEy6k+i2E=",
+        "lastModified": 1783793741,
+        "narHash": "sha256-3P6AvInE+cQwLhq8KQVhdcDkVgAXwKo9fzsBH1w2hMU=",
         "owner": "genebean",
         "repo": "my-oh-my-posh-themes",
-        "rev": "f93d5921f624ac9a3416807a43c13918f945d5d2",
+        "rev": "d4df6be1e5fd2ebfa34992bb4c824c0a4c16f28b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,9 @@
       ];
     in
     {
+      darwinModules.genebean = ./modules/genebean/darwin;
+      homeManagerModules.genebean = ./modules/genebean/home;
+
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
 
       # Darwin (macOS) hosts

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,14 @@
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
 
+    plasma-manager = {
+      url = "github:nix-community/plasma-manager";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        home-manager.follows = "home-manager";
+      };
+    };
+
     # Private flake for sensitive configs
     private-flake = {
       url = "github:genebean/private-flake";
@@ -154,6 +162,9 @@
       nixosConfigurations = {
         bigboy = localLib.mkNixosHost {
           hostname = "bigboy";
+          additionalHomeModules = [
+            inputs.plasma-manager.homeModules.plasma-manager
+          ];
           additionalModules = [
             inputs.nixos-hardware.nixosModules.lenovo-thinkpad-p52
           ];

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,9 +3,13 @@ let
   mkDarwinHost = import ./mkDarwinHost.nix { inherit inputs; };
   mkHomeConfig = import ./mkHomeConfig.nix { inherit inputs; };
   mkNixosHost = import ./mkNixosHost.nix { inherit inputs; };
+  genebeanLib = {
+    isNixOS = false;
+  };
 in
 {
   inherit (mkDarwinHost) mkDarwinHost;
   inherit (mkHomeConfig) mkHomeConfig;
   inherit (mkNixosHost) mkNixosHost;
+  inherit genebeanLib;
 }

--- a/lib/mkDarwinHost.nix
+++ b/lib/mkDarwinHost.nix
@@ -1,4 +1,7 @@
 { inputs, ... }:
+let
+  inherit (import ./default.nix { inherit inputs; }) genebeanLib;
+in
 {
   mkDarwinHost =
     {
@@ -29,7 +32,7 @@
         inputs.home-manager.darwinModules.home-manager
         {
           home-manager = {
-            extraSpecialArgs = { inherit inputs username; };
+            extraSpecialArgs = { inherit inputs genebeanLib username; };
             useGlobalPkgs = true;
             useUserPackages = true;
             users.${username}.imports = [
@@ -41,11 +44,13 @@
               inputs.genebean-neovim.homeManagerModules.default
               inputs.private-flake.homeManagerModules.private.git
               (inputs.private-flake.homeManagerModules.private.${hostname} or { })
+              inputs.self.homeManagerModules.genebean
               inputs.sops-nix.homeManagerModule # user-level secrets management
             ];
           };
         }
 
+        inputs.self.darwinModules.genebean
         ../modules/hosts/darwin # system-wide stuff
         ../modules/hosts/darwin/${hostname} # host specific stuff
       ]

--- a/lib/mkHomeConfig.nix
+++ b/lib/mkHomeConfig.nix
@@ -1,4 +1,7 @@
 { inputs, ... }:
+let
+  inherit (import ./default.nix { inherit inputs; }) genebeanLib;
+in
 {
   mkHomeConfig =
     {
@@ -10,6 +13,7 @@
       extraSpecialArgs = {
         inherit
           inputs
+          genebeanLib
           homeDirectory
           system
           username
@@ -37,6 +41,7 @@
         inputs.genebean-neovim.homeManagerModules.default
         inputs.nix-flatpak.homeManagerModules.nix-flatpak
         inputs.private-flake.homeManagerModules.private.git
+        inputs.self.homeManagerModules.genebean
         inputs.sops-nix.homeManagerModules.sops
       ];
     };

--- a/lib/mkHomeConfig.nix
+++ b/lib/mkHomeConfig.nix
@@ -40,6 +40,7 @@ in
 
         inputs.genebean-neovim.homeManagerModules.default
         inputs.nix-flatpak.homeManagerModules.nix-flatpak
+        inputs.plasma-manager.homeModules.plasma-manager
         inputs.private-flake.homeManagerModules.private.git
         inputs.self.homeManagerModules.genebean
         inputs.sops-nix.homeManagerModules.sops

--- a/lib/mkNixosHost.nix
+++ b/lib/mkNixosHost.nix
@@ -8,6 +8,7 @@ in
       system ? "x86_64-linux",
       hostname,
       username ? "gene",
+      additionalHomeModules ? [ ],
       additionalModules ? [ ],
       additionalSpecialArgs ? { },
     }:
@@ -46,7 +47,8 @@ in
               inputs.private-flake.homeManagerModules.private.git
               (inputs.private-flake.homeManagerModules.private.${hostname} or { })
               inputs.self.homeManagerModules.genebean
-            ];
+            ]
+            ++ additionalHomeModules;
           };
         }
 

--- a/lib/mkNixosHost.nix
+++ b/lib/mkNixosHost.nix
@@ -1,4 +1,7 @@
 { inputs, ... }:
+let
+  inherit (import ./default.nix { inherit inputs; }) genebeanLib;
+in
 {
   mkNixosHost =
     {
@@ -22,7 +25,16 @@
         inputs.home-manager.nixosModules.home-manager
         {
           home-manager = {
-            extraSpecialArgs = { inherit inputs hostname username; };
+            extraSpecialArgs = {
+              inherit
+                inputs
+                hostname
+                username
+                ;
+              genebeanLib = genebeanLib // {
+                isNixOS = true;
+              };
+            };
             useGlobalPkgs = true;
             useUserPackages = true;
             users.${username}.imports = [
@@ -33,6 +45,7 @@
               inputs.genebean-neovim.homeManagerModules.default
               inputs.private-flake.homeManagerModules.private.git
               (inputs.private-flake.homeManagerModules.private.${hostname} or { })
+              inputs.self.homeManagerModules.genebean
             ];
           };
         }

--- a/modules/genebean/darwin/default.nix
+++ b/modules/genebean/darwin/default.nix
@@ -1,0 +1,1 @@
+{ imports = [ ./ghostty.nix ]; }

--- a/modules/genebean/darwin/ghostty.nix
+++ b/modules/genebean/darwin/ghostty.nix
@@ -1,0 +1,11 @@
+{
+  config,
+  lib,
+  username,
+  ...
+}:
+{
+  config = lib.mkIf config.home-manager.users.${username}.genebean.ghostty.installViaHomebrew {
+    homebrew.casks = [ "ghostty" ];
+  };
+}

--- a/modules/genebean/home/default.nix
+++ b/modules/genebean/home/default.nix
@@ -1,0 +1,1 @@
+{ imports = [ ./ghostty.nix ]; }

--- a/modules/genebean/home/ghostty.nix
+++ b/modules/genebean/home/ghostty.nix
@@ -1,0 +1,83 @@
+{
+  config,
+  genebeanLib,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.genebean.ghostty;
+in
+{
+  options.genebean.ghostty = {
+    enable = lib.mkEnableOption "Ghostty terminal";
+    installViaHomebrew = lib.mkOption {
+      type = lib.types.bool;
+      default = pkgs.stdenv.isDarwin;
+    };
+    installViaNix = lib.mkOption {
+      type = lib.types.bool;
+      default = genebeanLib.isNixOS;
+    };
+    enableSystemd = lib.mkOption {
+      type = lib.types.bool;
+      default = genebeanLib.isNixOS;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.file = lib.mkIf pkgs.stdenv.isDarwin {
+      "Library/Application Support/com.mitchellh.ghostty/config".text = ''
+        # Ghostty configuration is managed by home-manager.
+        # Settings are in modules/genebean/home/ghostty.nix in the dots repo.
+      '';
+    };
+
+    programs.ghostty = {
+      enable = true;
+      package = if cfg.installViaNix then pkgs.ghostty else null;
+      enableZshIntegration = true;
+      systemd.enable = cfg.enableSystemd;
+      settings = {
+        font-family = "Hack Nerd Font Mono";
+        font-size = 14;
+        background-opacity = 0.92;
+        unfocused-split-opacity = 0.8;
+        split-divider-color = "#ffbf00";
+        window-padding-x = 5;
+        window-padding-y = 5;
+        window-padding-balance = true;
+        background = "07042B";
+        foreground = "E3E3EA";
+        cursor-color = "FF7F7F";
+        cursor-text = "07042B";
+        selection-background = "7DF9FF";
+        selection-foreground = "07042B";
+        palette = [
+          "0=#000000"
+          "1=#E52222"
+          "2=#55FF55"
+          "3=#F0C040"
+          "4=#C48DFF"
+          "5=#FA2573"
+          "6=#7DF9FF"
+          "7=#F2F2F2"
+          "8=#555555"
+          "9=#FF5555"
+          "10=#55FF55"
+          "11=#FFFF55"
+          "12=#6CB6FF"
+          "13=#FF55FF"
+          "14=#7DF9FF"
+          "15=#FFFFFF"
+        ];
+        keybind = [
+          "cmd+d=new_split:right"
+          "cmd+shift+d=new_split:down"
+          "super+d=new_split:right"
+          "super+shift+d=new_split:down"
+        ];
+      };
+    };
+  };
+}

--- a/modules/hosts/darwin/default.nix
+++ b/modules/hosts/darwin/default.nix
@@ -65,7 +65,6 @@
       "font-hack-nerd-font"
       "font-inconsolata-g-for-powerline"
       "font-source-code-pro-for-powerline"
-      "ghostty"
       "gitkraken"
       "gitkraken-cli"
       "handbrake-app"

--- a/modules/hosts/darwin/home.nix
+++ b/modules/hosts/darwin/home.nix
@@ -1,6 +1,6 @@
 { username, ... }:
 {
-  # dawrwin-specific shell config
+  # darwin-specific shell config
   programs = {
     zsh = {
       initContent = ''

--- a/modules/hosts/home-manager-only/default.nix
+++ b/modules/hosts/home-manager-only/default.nix
@@ -27,13 +27,22 @@
     ssh-to-age
   ];
 
-  programs.codex.enable = true;
+  programs = {
+    codex.enable = true;
 
-  # home-manager switch --flake ~/repos/dots
-  programs.zsh.shellAliases = {
-    nixdiff = "cd ~/repos/dots && home-manager build --flake .#${username}-${system} && nvd diff ${config.home.homeDirectory}/.local/state/nix/profiles/home-manager result";
-    nixup = "home-manager switch --flake ~/repos/dots#${username}-${system}";
-    pbcopy = "wl-copy";
+    plasma = {
+      enable = true;
+      shortcuts = {
+        kwin."Show Desktop" = [ ];
+      };
+    };
+
+    # home-manager switch --flake ~/repos/dots
+    zsh.shellAliases = {
+      nixdiff = "cd ~/repos/dots && home-manager build --flake .#${username}-${system} && nvd diff ${config.home.homeDirectory}/.local/state/nix/profiles/home-manager result";
+      nixup = "home-manager switch --flake ~/repos/dots#${username}-${system}";
+      pbcopy = "wl-copy";
+    };
   };
 
   sops = {

--- a/modules/hosts/home-manager-only/default.nix
+++ b/modules/hosts/home-manager-only/default.nix
@@ -16,6 +16,10 @@
     };
   };
 
+  genebean = {
+    ghostty.enable = true;
+  };
+
   home.packages = with pkgs; [
     age
     home-manager

--- a/modules/hosts/nixos/bigboy/home-gene.nix
+++ b/modules/hosts/nixos/bigboy/home-gene.nix
@@ -8,6 +8,12 @@
   ];
 
   programs = {
+    plasma = {
+      enable = true;
+      shortcuts = {
+        kwin."Show Desktop" = [ ];
+      };
+    };
     vscode = {
       enable = true;
     };

--- a/modules/shared/home/general/all-gui.nix
+++ b/modules/shared/home/general/all-gui.nix
@@ -1,5 +1,9 @@
 { pkgs, ... }:
 {
+  genebean = {
+    ghostty.enable = true;
+  };
+
   home.packages = with pkgs; [
     esptool
   ];


### PR DESCRIPTION
## Summary

- Introduces `modules/genebean/` — a reusable, option-driven module namespace where platform differences (NixOS / macOS / Ubuntu) are handled inside the module, not at the call site
- Adds `genebeanLib` (with `isNixOS` set explicitly per builder) as `extraSpecialArgs` in all three lib helpers, replacing an impure `builtins.pathExists /etc/NIXOS` probe that was unreliable under pure-eval
- Implements `genebean.ghostty` as the first module: full config (Beanbag-Mathias palette, Hack Nerd Font Mono, opacity, split keybinds, padding), Nix package on NixOS, Homebrew cask on macOS, Systemd socket on NixOS — driven by a single `genebean.ghostty.enable = true` at the call site
- Removes the hardcoded `ghostty` Homebrew cask from the shared Darwin module; it is now driven by the home-manager option via a companion `darwinModules.genebean` system module
- Adds `nix-community/plasma-manager` and clears the KDE `kwin/Show Desktop` shortcut on `bigboy` and the home-manager-only profile; adds `additionalHomeModules` parameter to `mkNixosHost` for per-host home-manager module injection
- Bumps the `genebean-omp-themes` flake input to the latest revision
- Documents the genebean module pattern fully in `AGENTS.md` and `README.md`

## Test plan

- [x] `darwin-rebuild switch` on a macOS host — verify `~/.config/ghostty/config` symlink created and Ghostty picks it up; verify Homebrew cask installed via the companion darwin module
- [x] Verify `~/Library/Application Support/com.mitchellh.ghostty/config` is managed (comments-only placeholder)
- [ ] Verify colors, font, opacity, split keybinds, and pane dimming look correct in Ghostty on both platforms
- [ ] `home-manager switch` on Ubuntu host — verify ghostty installed via Nix, systemd socket enabled
- [ ] Confirm `kwin Show Desktop` shortcut is cleared in KDE on bigboy and the home-manager-only profile
- [x] WezTerm still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)