### PR TITLE
feat(nixnuc): migrate from Wallabag to Karakeep

### DIFF
--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -15,6 +15,7 @@ in
   imports = [
     ./hardware-configuration.nix
     ./containers/audiobookshelf.nix
+    ./karakeep.nix
     ./containers/mountain-mesh-bot-discord.nix
     ./containers/photon.nix
     ./containers/psitransfer.nix
@@ -445,6 +446,25 @@ in
             send_timeout       600s;
           '';
         };
+        "karakeep.${home_domain}" = {
+          listen = [
+            {
+              inherit (config.dots.ports.https) port;
+              addr = "0.0.0.0";
+              ssl = true;
+            }
+          ];
+          enableACME = true;
+          acmeRoot = null;
+          forceSSL = true;
+          locations."/" = {
+            proxyPass = "http://127.0.0.1:${toString config.dots.ports.karakeep.port}";
+            proxyWebsockets = true;
+          };
+          extraConfig = ''
+            client_max_body_size 100M;
+          '';
+        };
         "jellyfin.${home_domain}" = {
           listen = [
             {
@@ -672,6 +692,13 @@ in
         restartUnits = [
           "firefly-iii-data-importer-setup.service"
           "phpfpm-firefly-iii-data-importer.service"
+        ];
+      };
+      karakeep_env = {
+        owner = "karakeep";
+        restartUnits = [
+          "karakeep-web.service"
+          "karakeep-workers.service"
         ];
       };
       immich_kiosk_basic_auth = {

--- a/modules/hosts/nixos/nixnuc/karakeep.nix
+++ b/modules/hosts/nixos/nixnuc/karakeep.nix
@@ -1,0 +1,22 @@
+{ config, ... }:
+let
+  home_domain = "home.technicalissues.us";
+in
+{
+  services.karakeep = {
+    enable = true;
+    environmentFile = config.sops.secrets.karakeep_env.path;
+    extraEnvironment = {
+      PORT = toString config.dots.ports.karakeep.port;
+      NEXTAUTH_URL = "https://karakeep.${home_domain}";
+      DISABLE_SIGNUPS = "true";
+      DISABLE_PASSWORD_AUTH = "true";
+      DISABLE_NEW_RELEASE_CHECK = "true";
+      OAUTH_WELLKNOWN_URL = "https://id.${home_domain}/.well-known/openid-configuration";
+      OAUTH_PROVIDER_NAME = "Pocket ID";
+      OAUTH_AUTO_REDIRECT = "true";
+    };
+  };
+
+  services.restic.backups.daily.paths = [ "/var/lib/karakeep" ];
+}

--- a/modules/hosts/nixos/nixnuc/ports.nix
+++ b/modules/hosts/nixos/nixnuc/ports.nix
@@ -27,6 +27,10 @@
       port = 3002;
       openFirewall = true;
     };
+    karakeep = {
+      port = 3003;
+      openFirewall = true;
+    };
     fireflyiii = {
       port = 3005;
       openFirewall = true;


### PR DESCRIPTION
Closes #685

## Summary

- Adds `services.karakeep` NixOS module at `karakeep.home.technicalissues.us` (port 3003)
- Configures Meilisearch, Chromium screenshots, OpenAI AI tagging, and Pocket ID OIDC auth
- Wires up sops secret and restic backup for `/var/lib/karakeep`

## Not yet done

See #685 for remaining steps — sops secret, Pocket ID app registration, rebuild, and data migration from Wallabag still pending.

## Test plan

- [ ] Add `karakeep_env` sops secret and register app in Pocket ID
- [ ] `sudo nixos-rebuild switch --flake .`
- [ ] Confirm Karakeep is reachable and Pocket ID login works
- [ ] Run migration script and verify Wallabag data appears in Karakeep

🤖 Generated with [Claude Code](https://claude.com/claude-code)