### PR TITLE
Move ports registry into genebean namespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,9 +184,9 @@ When writing NixOS modules:
 Service ports are managed through a two-level registry rather than scattered
 magic numbers:
 
-- `modules/shared/nixos/ports.nix` — defines the `dots.ports` option type and
+- `modules/genebean/nixos/ports.nix` — defines the `genebean.ports` option type and
   declares fleet-wide ports (ssh, http, https, shared service ports). All entries
-  default to `openFirewall = false`.
+  default to `openFirewall = false`. Imported automatically via `nixosModules.genebean`.
 - `modules/hosts/nixos/<hostname>/ports.nix` — host-specific ports plus any
   fleet-wide overrides (e.g. setting `openFirewall = true` for a port only that
   host exposes).
@@ -196,12 +196,12 @@ wire it directly to `networking.firewall` via `lib.pipe`:
 
 ```nix
 networking.firewall = {
-  allowedTCPPorts = lib.pipe config.dots.ports [
+  allowedTCPPorts = lib.pipe config.genebean.ports [
     builtins.attrValues
     (builtins.filter (e: e.openFirewall && e.protocol == "tcp"))
     (map (e: e.port))
   ];
-  allowedUDPPorts = lib.pipe config.dots.ports [
+  allowedUDPPorts = lib.pipe config.genebean.ports [
     builtins.attrValues
     (builtins.filter (e: e.openFirewall && e.protocol == "udp"))
     (map (e: e.port))
@@ -209,7 +209,7 @@ networking.firewall = {
 };
 ```
 
-Reference ports in config as `config.dots.ports.<name>.port` rather than
+Reference ports in config as `config.genebean.ports.<name>.port` rather than
 hardcoding numbers — this applies everywhere: service configs, nginx proxy
 targets, container definitions, and the firewall. When the surrounding attrset
 attribute name is already `port`, use `inherit` — statix rules W03/W04
@@ -218,10 +218,10 @@ if you use the verbose form where `inherit` would work:
 
 ```nix
 # rejected by statix W04
-port = config.dots.ports.grafana.port;
+port = config.genebean.ports.grafana.port;
 
 # correct
-inherit (config.dots.ports.grafana) port;
+inherit (config.genebean.ports.grafana) port;
 ```
 
 When adding a service that other hosts need to know about (e.g. a shared API

--- a/modules/genebean/nixos/default.nix
+++ b/modules/genebean/nixos/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./plasma.nix
+    ./ports.nix
     ./programs/askpass.nix
     ./programs/boinc.nix
     ./programs/firefox.nix

--- a/modules/genebean/nixos/ports.nix
+++ b/modules/genebean/nixos/ports.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 {
-  options.dots.ports = lib.mkOption {
+  options.genebean.ports = lib.mkOption {
     description = "Fleet-wide service port registry";
     default = { };
     type = lib.types.attrsOf (
@@ -32,7 +32,7 @@
   # by multiple hosts (e.g. hetznix01 references photon to configure Dawarich).
   # openFirewall is false by default; each host's ports.nix sets it to true
   # for the ports that host actually exposes.
-  config.dots.ports = {
+  config.genebean.ports = {
     ssh = {
       port = 22;
       openFirewall = true;

--- a/modules/hosts/nixos/bigboy/default.nix
+++ b/modules/hosts/nixos/bigboy/default.nix
@@ -8,7 +8,6 @@
   imports = [
     # Include the results of the hardware scan.
     ./hardware-configuration.nix
-    ../../../shared/nixos/ports.nix
     ../../../shared/nixos/ripping.nix
   ];
 

--- a/modules/hosts/nixos/hetznix01/default.nix
+++ b/modules/hosts/nixos/hetznix01/default.nix
@@ -7,7 +7,6 @@
 }:
 {
   imports = [
-    ../../../shared/nixos/ports.nix
     ./disk-config.nix
     ./hardware-configuration.nix
     ./ports.nix
@@ -31,12 +30,12 @@
 
   networking = {
     firewall = {
-      allowedTCPPorts = lib.pipe config.dots.ports [
+      allowedTCPPorts = lib.pipe config.genebean.ports [
         builtins.attrValues
         (builtins.filter (e: e.openFirewall && e.protocol == "tcp"))
         (map (e: e.port))
       ];
-      allowedUDPPorts = lib.pipe config.dots.ports [
+      allowedUDPPorts = lib.pipe config.genebean.ports [
         builtins.attrValues
         (builtins.filter (e: e.openFirewall && e.protocol == "udp"))
         (map (e: e.port))

--- a/modules/hosts/nixos/hetznix01/ports.nix
+++ b/modules/hosts/nixos/hetznix01/ports.nix
@@ -1,5 +1,5 @@
 {
-  config.dots.ports = {
+  config.genebean.ports = {
     # Firewalled TCP services (email)
     smtp = {
       port = 25;

--- a/modules/hosts/nixos/hetznix01/post-install/containers/emqx.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/containers/emqx.nix
@@ -16,10 +16,10 @@ in
       ];
       hostname = "emqx1.hetznix01.technicalissues.us";
       ports = [
-        "${toString config.dots.ports.mqtt.port}:1883"
+        "${toString config.genebean.ports.mqtt.port}:1883"
         #"8083:8083"
         #"8084:8084"
-        "${toString config.dots.ports.emqx-admin.port}:18083"
+        "${toString config.genebean.ports.emqx-admin.port}:18083"
       ];
       volumes = [
         "${volume_base}/data:/opt/emqx/data"

--- a/modules/hosts/nixos/hetznix01/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/default.nix
@@ -33,7 +33,7 @@ in
     };
     collabora-online = {
       enable = true;
-      inherit (config.dots.ports.collabora) port;
+      inherit (config.genebean.ports.collabora) port;
       settings = {
         # Rely on reverse proxy for SSL
         ssl = {
@@ -61,7 +61,7 @@ in
       enable = true;
       configureNginx = true;
       environment = {
-        PHOTON_API_HOST = "nixnuc.${config.private-flake.tailnetDomain}:${toString config.dots.ports.photon.port}";
+        PHOTON_API_HOST = "nixnuc.${config.private-flake.tailnetDomain}:${toString config.genebean.ports.photon.port}";
         PHOTON_API_USE_HTTPS = "false";
       };
       extraEnvFiles = [
@@ -132,7 +132,7 @@ in
       server = {
         baseUrl = "https://stats.${domain}";
         disableRegistration = true;
-        inherit (config.dots.ports.plausible) port;
+        inherit (config.genebean.ports.plausible) port;
         # secretKeybaseFile is a path to the file which contains the secret generated
         # with openssl as described above.
         secretKeybaseFile = config.sops.secrets.plausible_secret_key_base.path;

--- a/modules/hosts/nixos/hetznix01/post-install/matrix-synapse.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/matrix-synapse.nix
@@ -13,7 +13,7 @@
       signing_key_path = config.sops.secrets.matrix_homeserver_signing_key.path;
       listeners = [
         {
-          inherit (config.dots.ports.matrix-synapse) port;
+          inherit (config.genebean.ports.matrix-synapse) port;
           tls = false;
           type = "http";
           x_forwarded = true;

--- a/modules/hosts/nixos/hetznix01/post-install/monitoring.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/monitoring.nix
@@ -16,7 +16,7 @@ in
           {
             job_name = "node";
             static_configs = [
-              { targets = [ "127.0.0.1:${toString config.dots.ports.node-exporter.port}" ]; }
+              { targets = [ "127.0.0.1:${toString config.genebean.ports.node-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -37,7 +37,7 @@ in
           {
             job_name = "nginx";
             static_configs = [
-              { targets = [ "127.0.0.1:${toString config.dots.ports.nginx-exporter.port}" ]; }
+              { targets = [ "127.0.0.1:${toString config.genebean.ports.nginx-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -84,7 +84,7 @@ in
     prometheus.exporters.node = {
       enable = true;
       listenAddress = "127.0.0.1";
-      inherit (config.dots.ports.node-exporter) port;
+      inherit (config.genebean.ports.node-exporter) port;
       enabledCollectors = [
         "systemd"
       ];
@@ -98,7 +98,7 @@ in
     prometheus.exporters.nginx = {
       enable = true;
       listenAddress = "127.0.0.1";
-      inherit (config.dots.ports.nginx-exporter) port;
+      inherit (config.genebean.ports.nginx-exporter) port;
       scrapeUri = "https://127.0.0.1/server_status";
       sslVerify = false;
     };

--- a/modules/hosts/nixos/hetznix01/post-install/nginx.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/nginx.nix
@@ -23,13 +23,13 @@ in
     streamConfig = ''
       server {
         # https://docs.emqx.com/en/emqx/latest/deploy/cluster/lb-nginx.html
-        listen ${toString config.dots.ports.mqtt-tls.port} ssl;
+        listen ${toString config.genebean.ports.mqtt-tls.port} ssl;
         ssl_session_timeout 10m;
         ssl_certificate ${config.security.acme.certs."mqtt.${domain}".directory}/fullchain.pem;
         ssl_certificate_key ${config.security.acme.certs."mqtt.${domain}".directory}/key.pem;
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
-        proxy_pass 127.0.0.0:${toString config.dots.ports.mqtt.port};
+        proxy_pass 127.0.0.0:${toString config.genebean.ports.mqtt.port};
         proxy_protocol on;
         proxy_connect_timeout 10s;
         # Default keep-alive time is 10 minutes
@@ -39,17 +39,17 @@ in
       }
 
       server {
-        listen 0.0.0.0:${toString config.dots.ports.bitcoin-core.port};
-        listen 0.0.0.0:${toString config.dots.ports.bitcoin-knots.port};
-        listen [::]:${toString config.dots.ports.bitcoin-core.port};
-        listen [::]:${toString config.dots.ports.bitcoin-knots.port};
-        proxy_pass ${private_btc}:${toString config.dots.ports.bitcoin-core.port};
+        listen 0.0.0.0:${toString config.genebean.ports.bitcoin-core.port};
+        listen 0.0.0.0:${toString config.genebean.ports.bitcoin-knots.port};
+        listen [::]:${toString config.genebean.ports.bitcoin-core.port};
+        listen [::]:${toString config.genebean.ports.bitcoin-knots.port};
+        proxy_pass ${private_btc}:${toString config.genebean.ports.bitcoin-core.port};
       }
 
       server {
-        listen 0.0.0.0:${toString config.dots.ports.lnd.port};
-        listen [::]:${toString config.dots.ports.lnd.port};
-        proxy_pass ${private_btc}:${toString config.dots.ports.lnd.port};
+        listen 0.0.0.0:${toString config.genebean.ports.lnd.port};
+        listen [::]:${toString config.genebean.ports.lnd.port};
+        proxy_pass ${private_btc}:${toString config.genebean.ports.lnd.port};
       }
     '';
     virtualHosts = {
@@ -135,32 +135,32 @@ in
       "matrix.${domain}" = {
         listen = [
           {
-            inherit (config.dots.ports.http) port;
+            inherit (config.genebean.ports.http) port;
             addr = "0.0.0.0";
           }
           {
-            inherit (config.dots.ports.http) port;
+            inherit (config.genebean.ports.http) port;
             addr = "[::]";
           }
 
           {
-            inherit (config.dots.ports.https) port;
+            inherit (config.genebean.ports.https) port;
             addr = "0.0.0.0";
             ssl = true;
           }
           {
-            inherit (config.dots.ports.https) port;
+            inherit (config.genebean.ports.https) port;
             addr = "[::]";
             ssl = true;
           }
 
           {
-            inherit (config.dots.ports.matrix-federation) port;
+            inherit (config.genebean.ports.matrix-federation) port;
             addr = "0.0.0.0";
             ssl = true;
           }
           {
-            inherit (config.dots.ports.matrix-federation) port;
+            inherit (config.genebean.ports.matrix-federation) port;
             addr = "[::]";
             ssl = true;
           }
@@ -180,9 +180,9 @@ in
           };
           # Forward all Matrix API calls to the synapse Matrix homeserver. A trailing slash
           # *must not* be used here.
-          "/_matrix".proxyPass = "http://[::1]:${toString config.dots.ports.matrix-synapse.port}";
+          "/_matrix".proxyPass = "http://[::1]:${toString config.genebean.ports.matrix-synapse.port}";
           # Forward requests for e.g. SSO and password-resets.
-          "/_synapse/client".proxyPass = "http://[::1]:${toString config.dots.ports.matrix-synapse.port}";
+          "/_synapse/client".proxyPass = "http://[::1]:${toString config.genebean.ports.matrix-synapse.port}";
         };
       };
       "mqtt.${domain}" = {
@@ -203,7 +203,7 @@ in
         enableACME = true;
         acmeRoot = null;
         forceSSL = true;
-        locations."/".proxyPass = "http://127.0.0.1:${toString config.dots.ports.plausible.port}";
+        locations."/".proxyPass = "http://127.0.0.1:${toString config.genebean.ports.plausible.port}";
         locations."/".proxyWebsockets = true;
         extraConfig = ''
           access_log /var/log/nginx/stats.${domain}.log;
@@ -218,7 +218,7 @@ in
         acmeRoot = null;
         forceSSL = true;
         locations."/".proxyWebsockets = true;
-        locations."/".proxyPass = "http://127.0.0.1:${toString config.dots.ports.uptime-kuma.port}";
+        locations."/".proxyPass = "http://127.0.0.1:${toString config.genebean.ports.uptime-kuma.port}";
       };
     }; # end virtualHosts
   }; # end nginx

--- a/modules/hosts/nixos/hetznix02/default.nix
+++ b/modules/hosts/nixos/hetznix02/default.nix
@@ -8,7 +8,6 @@
 }:
 {
   imports = [
-    ../../../shared/nixos/ports.nix
     ./disk-config.nix
     ./hardware-configuration.nix
     ./post-install
@@ -36,12 +35,12 @@
 
   networking = {
     firewall = {
-      allowedTCPPorts = lib.pipe config.dots.ports [
+      allowedTCPPorts = lib.pipe config.genebean.ports [
         builtins.attrValues
         (builtins.filter (e: e.openFirewall && e.protocol == "tcp"))
         (map (e: e.port))
       ];
-      allowedUDPPorts = lib.pipe config.dots.ports [
+      allowedUDPPorts = lib.pipe config.genebean.ports [
         builtins.attrValues
         (builtins.filter (e: e.openFirewall && e.protocol == "udp"))
         (map (e: e.port))

--- a/modules/hosts/nixos/hetznix02/post-install/monitoring.nix
+++ b/modules/hosts/nixos/hetznix02/post-install/monitoring.nix
@@ -16,7 +16,7 @@ in
           {
             job_name = "node";
             static_configs = [
-              { targets = [ "127.0.0.1:${toString config.dots.ports.node-exporter.port}" ]; }
+              { targets = [ "127.0.0.1:${toString config.genebean.ports.node-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -37,7 +37,7 @@ in
           {
             job_name = "nginx";
             static_configs = [
-              { targets = [ "127.0.0.1:${toString config.dots.ports.nginx-exporter.port}" ]; }
+              { targets = [ "127.0.0.1:${toString config.genebean.ports.nginx-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -84,7 +84,7 @@ in
     prometheus.exporters.node = {
       enable = true;
       listenAddress = "127.0.0.1";
-      inherit (config.dots.ports.node-exporter) port;
+      inherit (config.genebean.ports.node-exporter) port;
       enabledCollectors = [
         "systemd"
       ];
@@ -98,7 +98,7 @@ in
     prometheus.exporters.nginx = {
       enable = true;
       listenAddress = "127.0.0.1";
-      inherit (config.dots.ports.nginx-exporter) port;
+      inherit (config.genebean.ports.nginx-exporter) port;
       scrapeUri = "https://127.0.0.1/server_status";
       sslVerify = false;
     };

--- a/modules/hosts/nixos/kiosk-entryway/default.nix
+++ b/modules/hosts/nixos/kiosk-entryway/default.nix
@@ -7,7 +7,6 @@
 }:
 {
   imports = [
-    ../../../shared/nixos/ports.nix
     ./disk-config.nix
     ./hardware-configuration.nix
     ./monitoring.nix

--- a/modules/hosts/nixos/kiosk-entryway/monitoring.nix
+++ b/modules/hosts/nixos/kiosk-entryway/monitoring.nix
@@ -16,7 +16,7 @@ in
           {
             job_name = "node";
             static_configs = [
-              { targets = [ "127.0.0.1:${toString config.dots.ports.node-exporter.port}" ]; }
+              { targets = [ "127.0.0.1:${toString config.genebean.ports.node-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -63,7 +63,7 @@ in
     prometheus.exporters.node = {
       enable = true;
       listenAddress = "127.0.0.1";
-      inherit (config.dots.ports.node-exporter) port;
+      inherit (config.genebean.ports.node-exporter) port;
       extraFlags = [
         "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|run|tmp|var/lib/docker/.+)($|/)"
         "--collector.diskstats.device-exclude=^(loop|ram|fd|sr|dm-|nvme[0-9]n[0-9]p[0-9]+_crypt)$"

--- a/modules/hosts/nixos/kiosk-gene-desk/default.nix
+++ b/modules/hosts/nixos/kiosk-gene-desk/default.nix
@@ -10,7 +10,6 @@
   imports = [
     # SD card image
     "${inputs.nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
-    ../../../shared/nixos/ports.nix
     ./read-only-root.nix
   ];
 
@@ -97,7 +96,7 @@
       };
     prometheus.exporters.node = {
       enable = true;
-      inherit (config.dots.ports.node-exporter) port;
+      inherit (config.genebean.ports.node-exporter) port;
       enabledCollectors = [
         "logind"
         "systemd"

--- a/modules/hosts/nixos/nixnuc/containers/audiobookshelf.nix
+++ b/modules/hosts/nixos/nixnuc/containers/audiobookshelf.nix
@@ -13,7 +13,7 @@ in
         AUDIOBOOKSHELF_UID = "99";
         AUDIOBOOKSHELF_GID = "100";
       };
-      ports = [ "${toString config.dots.ports.audiobookshelf.port}:80" ];
+      ports = [ "${toString config.genebean.ports.audiobookshelf.port}:80" ];
       volumes = [
         "${volume_base}/audiobooks:/audiobooks"
         "${volume_base}/podcasts:/podcasts"

--- a/modules/hosts/nixos/nixnuc/containers/photon.nix
+++ b/modules/hosts/nixos/nixnuc/containers/photon.nix
@@ -18,7 +18,7 @@ in
         UPDATE_STRATEGY = "PARALLEL";
         UPDATE_INTERVAL = "30d";
       };
-      ports = [ "${toString config.dots.ports.photon.port}:2322" ];
+      ports = [ "${toString config.genebean.ports.photon.port}:2322" ];
       volumes = [
         "${volume_base}:/photon/data"
       ];

--- a/modules/hosts/nixos/nixnuc/containers/psitransfer.nix
+++ b/modules/hosts/nixos/nixnuc/containers/psitransfer.nix
@@ -23,7 +23,7 @@ in
       autoStart = true;
       image = "psitrax/psitransfer:v2.4.4";
       environmentFiles = [ psitransfer_dot_env ];
-      ports = [ "${toString config.dots.ports.psitransfer.port}:3000" ];
+      ports = [ "${toString config.genebean.ports.psitransfer.port}:3000" ];
       volumes = [
         "${volume_base}/data:/data"
       ];

--- a/modules/hosts/nixos/nixnuc/cup-collector.nix
+++ b/modules/hosts/nixos/nixnuc/cup-collector.nix
@@ -22,9 +22,9 @@ in
       ];
       migrationsDir = inputs.cup-collector.packages.${pkgs.stdenv.hostPlatform.system}.migrations;
       pbBindIp = "0.0.0.0";
-      pbPort = config.dots.ports.pocketbase.port; # override default due to conflict
+      pbPort = config.genebean.ports.pocketbase.port; # override default due to conflict
       pocketidIssuerUrl = config.services.pocket-id.settings.APP_URL;
-      inherit (config.dots.ports.cup-collector) port; # override default due to conflict
+      inherit (config.genebean.ports.cup-collector) port; # override default due to conflict
     };
 
     restic.backups.daily = {

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -23,7 +23,6 @@ in
     ./ports.nix
     ./zfs-datasets.nix
     ../../../shared/nixos/lets-encrypt.nix
-    ../../../shared/nixos/ports.nix
     ../../../shared/nixos/restic.nix
   ];
 
@@ -74,12 +73,12 @@ in
 
   networking = {
     firewall = {
-      allowedTCPPorts = lib.pipe config.dots.ports [
+      allowedTCPPorts = lib.pipe config.genebean.ports [
         builtins.attrValues
         (builtins.filter (e: e.openFirewall && e.protocol == "tcp"))
         (map (e: e.port))
       ];
-      allowedUDPPorts = lib.pipe config.dots.ports [
+      allowedUDPPorts = lib.pipe config.genebean.ports [
         builtins.attrValues
         (builtins.filter (e: e.openFirewall && e.protocol == "udp"))
         (map (e: e.port))
@@ -161,7 +160,7 @@ in
       enable = true;
       enableNginx = true;
       settings = {
-        FIREFLY_III_URL = "http://localhost:${toString config.dots.ports.fireflyiii.port}";
+        FIREFLY_III_URL = "http://localhost:${toString config.genebean.ports.fireflyiii.port}";
         VANITY_URL_FILE = "${config.sops.secrets.firefly_vanity_url.path}";
         FIREFLY_III_ACCESS_TOKEN_FILE = "${config.sops.secrets.firefly_pat_data_import.path}";
         SIMPLEFIN_TOKEN_FILE = "${config.sops.secrets.firefly_simplefin_token.path}";
@@ -187,7 +186,7 @@ in
         };
         server = {
           DOMAIN = "git.${home_domain}";
-          HTTP_PORT = config.dots.ports.forgejo.port;
+          HTTP_PORT = config.genebean.ports.forgejo.port;
           LANDING_PAGE = "explore";
           ROOT_URL = "https://git.${home_domain}/";
         };
@@ -206,7 +205,7 @@ in
       enable = true;
       credentialsFile = config.sops.secrets.mealie.path;
       listenAddress = "0.0.0.0";
-      inherit (config.dots.ports.mealie) port;
+      inherit (config.genebean.ports.mealie) port;
       settings = {
         ALLOW_SIGNUP = "false";
         BASE_URL = "https://mealie.${home_domain}";
@@ -303,7 +302,7 @@ in
           ];
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -328,7 +327,7 @@ in
         "ab.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -337,7 +336,8 @@ in
           acmeRoot = null;
           forceSSL = true;
           locations."/".proxyWebsockets = true;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.audiobookshelf.port}";
+          locations."/".proxyPass =
+            "http://${backend_ip}:${toString config.genebean.ports.audiobookshelf.port}";
           extraConfig = ''
             client_max_body_size 0;
           '';
@@ -345,7 +345,7 @@ in
         "atuin.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -353,19 +353,19 @@ in
           enableACME = true;
           acmeRoot = null;
           forceSSL = true;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.atuin.port}";
+          locations."/".proxyPass = "http://${backend_ip}:${toString config.genebean.ports.atuin.port}";
         };
         # budget.${home_domain}
         "${config.services.firefly-iii.virtualHost}".listen = [
           {
-            inherit (config.dots.ports.fireflyiii) port;
+            inherit (config.genebean.ports.fireflyiii) port;
             addr = "0.0.0.0";
             ssl = false;
           }
         ];
         "${config.services.firefly-iii-data-importer.virtualHost}".listen = [
           {
-            inherit (config.dots.ports.fireflyiii-importer) port;
+            inherit (config.genebean.ports.fireflyiii-importer) port;
             addr = "0.0.0.0";
             ssl = false;
           }
@@ -373,7 +373,7 @@ in
         "git.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -381,7 +381,7 @@ in
           enableACME = true;
           acmeRoot = null;
           forceSSL = true;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.forgejo.port}";
+          locations."/".proxyPass = "http://${backend_ip}:${toString config.genebean.ports.forgejo.port}";
           extraConfig = ''
             client_max_body_size 0;
           '';
@@ -389,7 +389,7 @@ in
         "id.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -397,7 +397,7 @@ in
           enableACME = true;
           acmeRoot = null;
           forceSSL = true;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.pocket-id.port}";
+          locations."/".proxyPass = "http://${backend_ip}:${toString config.genebean.ports.pocket-id.port}";
           extraConfig = ''
             proxy_busy_buffers_size   512k;
             proxy_buffers           4 512k;
@@ -407,7 +407,7 @@ in
         "immich.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -415,7 +415,7 @@ in
           enableACME = true;
           acmeRoot = null;
           forceSSL = true;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.immich.port}";
+          locations."/".proxyPass = "http://${backend_ip}:${toString config.genebean.ports.immich.port}";
           locations."/".proxyWebsockets = true;
           extraConfig = ''
             client_max_body_size 0;
@@ -427,7 +427,7 @@ in
         "immich-kiosk.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -436,7 +436,8 @@ in
           acmeRoot = null;
           forceSSL = true;
           basicAuthFile = config.sops.secrets.immich_kiosk_basic_auth.path;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.immich-kiosk.port}";
+          locations."/".proxyPass =
+            "http://${backend_ip}:${toString config.genebean.ports.immich-kiosk.port}";
           locations."/".proxyWebsockets = true;
           extraConfig = ''
             client_max_body_size 0;
@@ -448,7 +449,7 @@ in
         "jellyfin.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -458,14 +459,14 @@ in
           forceSSL = true;
           locations = {
             "/" = {
-              proxyPass = "http://${backend_ip}:${toString config.dots.ports.jellyfin.port}";
+              proxyPass = "http://${backend_ip}:${toString config.genebean.ports.jellyfin.port}";
               extraConfig = ''
                 proxy_buffering off;
                 proxy_set_header X-Forwarded-Protocol $scheme;
               '';
             };
             "/socket" = {
-              proxyPass = "http://${backend_ip}:${toString config.dots.ports.jellyfin.port}";
+              proxyPass = "http://${backend_ip}:${toString config.genebean.ports.jellyfin.port}";
               proxyWebsockets = true;
               extraConfig = ''
                 proxy_set_header X-Forwarded-Protocol $scheme;
@@ -479,7 +480,7 @@ in
         "mealie.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -487,7 +488,7 @@ in
           enableACME = true;
           acmeRoot = null;
           forceSSL = true;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.mealie.port}";
+          locations."/".proxyPass = "http://${backend_ip}:${toString config.genebean.ports.mealie.port}";
           extraConfig = ''
             client_max_body_size 10M;
           '';
@@ -495,7 +496,7 @@ in
         "monitoring.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -504,10 +505,11 @@ in
           acmeRoot = null;
           forceSSL = true;
           locations = {
-            "/grafana/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.grafana.port}/grafana/";
+            "/grafana/".proxyPass =
+              "http://${backend_ip}:${toString config.genebean.ports.grafana.port}/grafana/";
             "/remotewrite" = {
               basicAuthFile = config.sops.secrets.nginx_basic_auth.path;
-              proxyPass = "http://127.0.0.1:${toString config.dots.ports.victoriametrics.port}/api/v1/write";
+              proxyPass = "http://127.0.0.1:${toString config.genebean.ports.victoriametrics.port}/api/v1/write";
               proxyWebsockets = true;
             };
           };
@@ -520,7 +522,7 @@ in
         "readit.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -528,12 +530,12 @@ in
           enableACME = true;
           acmeRoot = null;
           forceSSL = true;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.wallabag.port}";
+          locations."/".proxyPass = "http://${backend_ip}:${toString config.genebean.ports.wallabag.port}";
         };
         "ytdlfin.${home_domain}" = {
           listen = [
             {
-              inherit (config.dots.ports.https) port;
+              inherit (config.genebean.ports.https) port;
               addr = "0.0.0.0";
               ssl = true;
             }
@@ -541,9 +543,9 @@ in
           enableACME = true;
           acmeRoot = null;
           forceSSL = true;
-          locations."/".proxyPass = "http://${backend_ip}:${toString config.dots.ports.ytdlfin.port}";
+          locations."/".proxyPass = "http://${backend_ip}:${toString config.genebean.ports.ytdlfin.port}";
           locations."= /health" = {
-            proxyPass = "http://${backend_ip}:${toString config.dots.ports.ytdlfin.port}";
+            proxyPass = "http://${backend_ip}:${toString config.genebean.ports.ytdlfin.port}";
             extraConfig = ''
               limit_req zone=ytdlfin_health burst=3 nodelay;
             '';
@@ -631,7 +633,7 @@ in
       enable = true;
       user = config.services.jellyfin.user;
       group = config.services.jellyfin.group;
-      port = config.dots.ports.ytdlfin.port;
+      port = config.genebean.ports.ytdlfin.port;
       stagingDir = "/orico/jellyfin/staging/.ytdlfin-staging";
       environmentFile = config.sops.secrets.ytdlfin-env.path;
       settings = {

--- a/modules/hosts/nixos/nixnuc/monitoring-stack.nix
+++ b/modules/hosts/nixos/nixnuc/monitoring-stack.nix
@@ -49,9 +49,9 @@ in
             static_configs = [
               {
                 targets = [
-                  "127.0.0.1:${toString config.dots.ports.node-exporter.port}" # nixnuc
-                  "192.168.22.22:${toString config.dots.ports.node-exporter.port}" # home assistant
-                  "umbrel:${toString config.dots.ports.node-exporter.port}"
+                  "127.0.0.1:${toString config.genebean.ports.node-exporter.port}" # nixnuc
+                  "192.168.22.22:${toString config.genebean.ports.node-exporter.port}" # home assistant
+                  "umbrel:${toString config.genebean.ports.node-exporter.port}"
                 ];
               }
             ];
@@ -89,7 +89,7 @@ in
           {
             job_name = "cadvisor";
             static_configs = [
-              { targets = [ "127.0.0.1:${toString config.dots.ports.cadvisor.port}" ]; }
+              { targets = [ "127.0.0.1:${toString config.genebean.ports.cadvisor.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -110,7 +110,7 @@ in
           {
             job_name = "nginx";
             static_configs = [
-              { targets = [ "127.0.0.1:${toString config.dots.ports.nginx-exporter.port}" ]; }
+              { targets = [ "127.0.0.1:${toString config.genebean.ports.nginx-exporter.port}" ]; }
             ];
             metric_relabel_configs = [
               {
@@ -181,7 +181,7 @@ in
       };
 
       # Remote write to VictoriaMetrics
-      remoteWrite.url = "http://127.0.0.1:${toString config.dots.ports.victoriametrics.port}/api/v1/write";
+      remoteWrite.url = "http://127.0.0.1:${toString config.genebean.ports.victoriametrics.port}/api/v1/write";
 
       extraArgs = [
         # Pass other remote write flags the module does not expose natively:
@@ -219,7 +219,7 @@ in
             name = "VictoriaMetrics";
             type = "victoriametrics-metrics-datasource";
             access = "proxy";
-            url = "http://127.0.0.1:${toString config.dots.ports.victoriametrics.port}";
+            url = "http://127.0.0.1:${toString config.genebean.ports.victoriametrics.port}";
             isDefault = true;
             uid = "VictoriaMetrics"; # Set explicit UID for use in alert rules
           }
@@ -274,7 +274,7 @@ in
         server = {
           domain = "monitoring.${home_domain}";
           http_addr = "0.0.0.0";
-          http_port = config.dots.ports.grafana.port;
+          http_port = config.genebean.ports.grafana.port;
           root_url = "https://monitoring.${home_domain}/grafana/";
           serve_from_sub_path = true;
         };
@@ -297,7 +297,7 @@ in
     prometheus.exporters.node = {
       enable = true;
       listenAddress = "127.0.0.1";
-      inherit (config.dots.ports.node-exporter) port;
+      inherit (config.genebean.ports.node-exporter) port;
       enabledCollectors = [
         "zfs"
         "systemd"
@@ -312,7 +312,7 @@ in
     prometheus.exporters.nginx = {
       enable = true;
       listenAddress = "127.0.0.1";
-      inherit (config.dots.ports.nginx-exporter) port;
+      inherit (config.genebean.ports.nginx-exporter) port;
       scrapeUri = "https://127.0.0.1/server_status";
       sslVerify = false;
     };
@@ -321,7 +321,7 @@ in
     cadvisor = {
       enable = true;
       listenAddress = "127.0.0.1";
-      inherit (config.dots.ports.cadvisor) port;
+      inherit (config.genebean.ports.cadvisor) port;
       extraOptions = [
         "--docker_only=true"
         "--housekeeping_interval=30s"

--- a/modules/hosts/nixos/nixnuc/ports.nix
+++ b/modules/hosts/nixos/nixnuc/ports.nix
@@ -1,6 +1,6 @@
 # Entries within each section are sorted by port number in ascending order.
 {
-  config.dots.ports = {
+  config.genebean.ports = {
     # Override global photon default: open the firewall on this host
     photon = {
       openFirewall = true;

--- a/modules/hosts/nixos/rainbow-planet/default.nix
+++ b/modules/hosts/nixos/rainbow-planet/default.nix
@@ -8,7 +8,6 @@
 {
   imports = [
     ./hardware-configuration.nix
-    ../../../shared/nixos/ports.nix
     ../../../shared/nixos/ripping.nix
   ];
 


### PR DESCRIPTION
## Summary

- Moves `modules/shared/nixos/ports.nix` → `modules/genebean/nixos/ports.nix`
- Renames option namespace from `dots.ports` to `genebean.ports`
- Module is now imported automatically via `nixosModules.genebean`, removing the need for the explicit `shared/nixos/ports.nix` import in each host's `default.nix`
- Updates all references to `config.dots.ports` across all host modules
- Updates `AGENTS.md` to reflect new path and namespace

## Test plan

- [x] `pre-commit run --all-files` passes ✅
- [x] Applied on nixnuc (NixOS headless)
- [x] Applied on bigboy (NixOS GUI)
- [x] Applied on hetznix01
- [x] Applied on hetznix02

🤖 Generated with [Claude Code](https://claude.com/claude-code)