### PR TITLE
Add genebean.programs.atuin-client and genebean.programs.bat modules

### DIFF
--- a/modules/genebean/home/default.nix
+++ b/modules/genebean/home/default.nix
@@ -3,6 +3,8 @@
     ./plasma.nix
     ./programs/angry-ip-scanner.nix
     ./programs/askpass.nix
+    ./programs/atuin-client.nix
+    ./programs/bat.nix
     ./programs/boinc.nix
     ./programs/caffeine.nix
     ./programs/audacity.nix

--- a/modules/genebean/home/programs/atuin-client.nix
+++ b/modules/genebean/home/programs/atuin-client.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+let
+  cfg = config.genebean.programs.atuin-client;
+in
+{
+  options.genebean.programs.atuin-client = {
+    enable = lib.mkEnableOption "Atuin shell history client";
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.atuin = {
+      enable = true;
+      settings = {
+        ctrl_n_shortcuts = true; # Use Ctrl-0 .. Ctrl-9 instead of Alt-0 .. Alt-9 UI shortcuts
+        enter_accept = true; # press tab to edit command before running
+        filter_mode_shell_up_key_binding = "host"; # or global, host, directory, etc
+        sync_address = "https://atuin.home.technicalissues.us";
+        sync_frequency = "15m";
+      };
+    };
+  };
+}

--- a/modules/genebean/home/programs/atuin-client.nix
+++ b/modules/genebean/home/programs/atuin-client.nix
@@ -13,6 +13,7 @@ in
       settings = {
         ctrl_n_shortcuts = true; # Use Ctrl-0 .. Ctrl-9 instead of Alt-0 .. Alt-9 UI shortcuts
         enter_accept = true; # press tab to edit command before running
+        filter_mode = "host"; # or global, host, session, directory, etc
         filter_mode_shell_up_key_binding = "host"; # or global, host, directory, etc
         sync_address = "https://atuin.home.technicalissues.us";
         sync_frequency = "15m";

--- a/modules/genebean/home/programs/bat.nix
+++ b/modules/genebean/home/programs/bat.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.genebean.programs.bat;
+in
+{
+  options.genebean.programs.bat = {
+    enable = lib.mkEnableOption "bat, a cat clone with syntax highlighting";
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.bat = {
+      enable = true;
+      config = {
+        theme = "Catppuccin-frappe";
+      };
+      themes = {
+        Catppuccin-frappe = {
+          src = pkgs.fetchFromGitHub {
+            owner = "catppuccin";
+            repo = "bat";
+            rev = "ba4d16880d63e656acced2b7d4e034e4a93f74b1";
+            hash = "sha256-6WVKQErGdaqb++oaXnY3i6/GuH2FhTgK0v4TN4Y0Wbw=";
+          };
+          file = "Catppuccin-frappe.tmTheme";
+        };
+      };
+    };
+  };
+}

--- a/modules/shared/home/general/default.nix
+++ b/modules/shared/home/general/default.nix
@@ -7,6 +7,8 @@
 {
   genebean = {
     programs = {
+      atuin-client.enable = true;
+      bat.enable = true;
       claude-code.enable = true;
       diff.enable = true;
       git.enable = true;
@@ -78,34 +80,6 @@
     };
   };
   programs = {
-    atuin = {
-      enable = true;
-      settings = {
-        ctrl_n_shortcuts = true; # Use Ctrl-0 .. Ctrl-9 instead of Alt-0 .. Alt-9 UI shortcuts
-        enter_accept = true; # press tab to edit command before running
-        filter_mode_shell_up_key_binding = "host"; # or global, host, directory, etc
-        sync_address = "https://atuin.home.technicalissues.us";
-        sync_frequency = "15m";
-
-      };
-    };
-    bat = {
-      enable = true;
-      config = {
-        theme = "Catppuccin-frappe";
-      };
-      themes = {
-        Catppuccin-frappe = {
-          src = pkgs.fetchFromGitHub {
-            owner = "catppuccin";
-            repo = "bat";
-            rev = "ba4d16880d63e656acced2b7d4e034e4a93f74b1";
-            hash = "sha256-6WVKQErGdaqb++oaXnY3i6/GuH2FhTgK0v4TN4Y0Wbw=";
-          };
-          file = "Catppuccin-frappe.tmTheme";
-        };
-      };
-    };
     bottom.enable = true;
     broot.enable = true;
     direnv = {


### PR DESCRIPTION
## Summary

- Extracts `programs.atuin` from `shared/home/general/default.nix` into `genebean.programs.atuin-client` (named with `-client` suffix to distinguish the desktop client from the server)
- Extracts `programs.bat` (with Catppuccin Frappé theme) into `genebean.programs.bat`
- Both enabled in `shared/home/general/default.nix` via their `.enable` options

## Test plan

- [x] `pre-commit run --all-files` passes
- [ ] Applied on bigboy (NixOS GUI)
- [ ] Applied on mightymac (nix-darwin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)