### PR TITLE
Deploy social-reader-mcp (HermesSocialSummerizer) to nixnuc

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -423,6 +423,26 @@
         "type": "github"
       }
     },
+    "hermes-social-summerizer": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784171483,
+        "narHash": "sha256-I63JtT1voBxBwDnF0zBOa78u9b7udL7ymbI2cZa0tzo=",
+        "owner": "genebean",
+        "repo": "HermesSocialSummerizer",
+        "rev": "fc2d6255b3333fa0c35612235576232d6097ed0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "genebean",
+        "repo": "HermesSocialSummerizer",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -819,6 +839,7 @@
         "flox": "flox",
         "genebean-neovim": "genebean-neovim",
         "genebean-omp-themes": "genebean-omp-themes",
+        "hermes-social-summerizer": "hermes-social-summerizer",
         "home-manager": "home-manager",
         "nix-auth": "nix-auth",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,11 @@
       flake = false;
     };
 
+    hermes-social-summerizer = {
+      url = "github:genebean/HermesSocialSummerizer";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Manages things in home directory
     home-manager = {
       url = "github:nix-community/home-manager/release-26.05";
@@ -199,6 +204,7 @@
           hostname = "nixnuc";
           additionalModules = [
             inputs.cup-collector.nixosModules.default
+            inputs.hermes-social-summerizer.nixosModules.default
             inputs.private-flake.nixosModules.private.nixnuc
             inputs.ytdlfin.nixosModules.default
           ];

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -21,6 +21,7 @@ in
     ./cup-collector.nix
     ./monitoring-stack.nix
     ./ports.nix
+    ./social-reader-mcp.nix
     ./zfs-datasets.nix
     ../../../shared/nixos/lets-encrypt.nix
     ../../../shared/nixos/restic.nix

--- a/modules/hosts/nixos/nixnuc/ports.nix
+++ b/modules/hosts/nixos/nixnuc/ports.nix
@@ -76,6 +76,12 @@
       openFirewall = true;
     };
 
+    # Firewalled TCP services continued
+    social-reader-mcp = {
+      port = 8787;
+      openFirewall = true;
+    };
+
     # Internal-only TCP services (proxied via nginx, not firewalled)
     pocket-id = {
       port = 1411;

--- a/modules/hosts/nixos/nixnuc/secrets.yaml
+++ b/modules/hosts/nixos/nixnuc/secrets.yaml
@@ -18,6 +18,7 @@ nginx_basic_auth: ENC[AES256_GCM,data:9qy8ccV9yWOrQtagf4D4fTp4v8GuY5ORxsE8hUv/vK
 pocketid_encryption_key: ENC[AES256_GCM,data:N/V1XHU4NZOL02KJL6kqec9NyJl1UQI4q626j7apFxfz/LMXNavQQ8eKDtrY,iv:ukJAEWKq3SX1iU8qXhxEAGVlovY5N8FTwdShgMQ+zig=,tag:U9eWbhaPySsYlyhS+dEoQQ==,type:str]
 psitransfer_dot_env: ENC[AES256_GCM,data:bhvU0AOCjecZ62BtLw4H1DdkLeatI+uUl6L7UkdDRkBF3sayO45Z1eR4q60tflXucyTGhT8WgKFz53I+C2dn265wzojIRc3Xr4TBLyWpfJ7/dct40SckgUiRvOnrefiriWQ=,iv:DGMhDkzgeupzzTJnCdVWDPUSo2wxI3MAypKQwVfHExE=,tag:KbteGqrkqgj2XB1lvlk/yQ==,type:str]
 pinchflat_dot_env: ENC[AES256_GCM,data:8DLiFXThG5PGJ0ymW5bMVy5A8dM=,iv:BGkVvxaNwFIMSaA3F6h4ZsgkC9tm1lohA0lg2pgZhpw=,tag:qQNrluP5exdKG3NXgQHM8g==,type:str]
+social_reader_mcp_env: ENC[AES256_GCM,data:w+jujihm4bAAF8+dZ6pXOZD6arAdvhlj8e7IKrSJA0yMeIWQDjfsIiemoYwb1P7CHFsf9F9g5LvtwcWf2uo0yFOHoB/GdGVhnO8M87J90IoFfNYLsMCUhxNQagPBvDpe6BpwWGab+vU19zKtzEAWHwV5w04Osp3h75J7GHsaeXxpCS5cNcFvZpOy6fEXo9Z3hscQZ36PMCnqaVUjPA2fgqYXyB0UOpkSbbYyMyeZeMQM2jzwtg==,iv:+f9MZbiFI7x8zdA3n18Hiq9AOrWzfmpIRywbhyWKgTw=,tag:K/nyvcmUguvW5IFYkrs3mw==,type:str]
 tandoor_db_pass: ENC[AES256_GCM,data:X0unx5jquLsUXadbF6xLjjeGY+f8Ec4kdc15JQ==,iv:XptlJHfAkF+3jbgJTqxhVReYjuVVdk3NzfPepP78DRI=,tag:3RG5P9QGCJ/fjdxWpY1xWA==,type:str]
 tandoor_secret_key: ENC[AES256_GCM,data:aSQRdtWUZQzy5rvQBPAvYFvwTqyu16UGrvUayxqi2WdsTOfqOyxQ7ywNEy/g/qPqSbwM,iv:kbct/gvfYhU6GOhkomY80o/Sx5mr9FY9SAFJGNrj3Ow=,tag:v+LKQ9UM5nzzd77By7TnGg==,type:str]
 ytdlfin-env: ENC[AES256_GCM,data:X33y2zqG7XRhUX0F7YoT8clGoOzTuBKTaKbyZ5/2UmFJfg5xxRYieelRwKxAw/FvZoMEHRaugXYfHinCjOvRT6+Zgk5BOiV1f4TvRInTAIrMq8ApFlYvsUS7rS6q1g9Q5/h/gmOmEaa400+7Aml4fuHUaIEJG3OBGQEdZc97pLLsfmBAG+uYxxom6+msXJ494Ua1cnfbsjcvVReJiIa1TjRH3BN8LrJY42UEv4QSGFhyJKEpNtJre3t+,iv:4pyijslimg8SKBt1EzuwFGxxAy3nDYk9razfEbfj+EE=,tag:blmVpDS1GDx/7kQEDVLkJg==,type:str]
@@ -32,7 +33,7 @@ sops:
             PF025X9U+yG2oIopwXEVBkxcD70eyuJn3OqH0xoVLBkbhNM9i8LHrA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1g24zhwvgenpc4wqejt63thvgd4rn5x9n7nnwwme7dm83nfqpp93se2vmq4
-    lastmodified: "2026-06-13T23:53:00Z"
-    mac: ENC[AES256_GCM,data:flcQgdp3x15cy/SY8FwF3LWJy54l4Si/mW3dXhjFWCBO/qPoceAqgFSRKnZsNxtJYZWP3n43gqpMLQQXk7667VoDC/YDrAZRZVbdQXakXmxZzASBki2BX6iT2JQ1+VDeo4tpK5WGH3aL6uhzwtw1a3GQEGkysV/D1Vb7mXv7U6A=,iv:dTofpuoxJabzw34L+Wm6VszRkVGTr19lCblwbE0umdI=,tag:+AR2ndMOwDgl3QPWUYZhpQ==,type:str]
+    lastmodified: "2026-07-16T02:52:27Z"
+    mac: ENC[AES256_GCM,data:ozer784MBv/26PxUK4cFdyvD+7psTJpgneibsAzCykKvY7Sf0R3x0TpbE68kq1UCLDFNdXlgz1DRHZwR51qELl+diQJKFAqYH6agjniUUHHP2B5oAx4Fny6nxhmjXAOndcwKzYuN8pYay6/MotNTH25v29jdqZXZvK3M61McT1E=,iv:jNS2wz1kUJfIS/w+N/h3gSlvWLLfWBJHWJN/TBvUu5Y=,tag:eapj96F2DNPhXJ0DyBN1Rw==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.13.1
+    version: 3.13.2

--- a/modules/hosts/nixos/nixnuc/social-reader-mcp.nix
+++ b/modules/hosts/nixos/nixnuc/social-reader-mcp.nix
@@ -1,0 +1,66 @@
+{
+  config,
+  ...
+}:
+{
+  services.social-reader-mcp = {
+    enable = true;
+
+    bluesky = [
+      {
+        appPasswordEnv = "BSKY_PERSONAL_APP_PW";
+        handle = "genebean.bsky.social";
+        id = "personal";
+      }
+    ];
+
+    http = {
+      enable = true;
+
+      bindAddress = "0.0.0.0";
+      environmentFile = config.sops.secrets.social_reader_mcp_env.path;
+      # Bind on all interfaces — LAN-only access, no nginx proxy in front.
+      # The bearer token (SOCIAL_READER_MCP_HTTP_TOKEN in environmentFile)
+      # is the sole auth mechanism.
+      port = config.genebean.ports.social-reader-mcp.port;
+    };
+
+    mastodon = [
+      {
+        accessTokenEnv = "MASTODON_MAIN_TOKEN";
+        id = "main";
+        instanceUrl = "https://fosstodon.org";
+      }
+    ];
+
+    nostr = [
+      {
+        id = "main";
+        npub = "npub1mwsk3ly4lk7efdqqjm62dkc699kqapwyyvdley3xljjm0lxruh9qzvu46p";
+        relays = [
+          "wss://nostr.data.haus"
+          "wss://relay.primal.net"
+          "wss://relay.damus.io"
+        ];
+      }
+    ];
+
+    user = "social-reader-mcp";
+  };
+
+  # Dedicated system user — required so sops can assign ownership of the
+  # EnvironmentFile and tmpfiles can create the cursor-state directory with
+  # a known, persistent owner (DynamicUser doesn't work here for that reason).
+  sops.secrets.social_reader_mcp_env = {
+    owner = "social-reader-mcp";
+    restartUnits = [ "social-reader-mcp-http.service" ];
+  };
+
+  users = {
+    groups.social-reader-mcp = { };
+    users.social-reader-mcp = {
+      group = "social-reader-mcp";
+      isSystemUser = true;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `hermes-social-summerizer` as a flake input pointing to `github:genebean/HermesSocialSummerizer`
- Wires its NixOS module into nixnuc's `additionalModules`
- New `social-reader-mcp.nix` host module configures the service with Mastodon, Bluesky, and Nostr accounts, a dedicated system user, and a sops-managed `EnvironmentFile` for secrets
- Port 8787 registered in the nixnuc port registry with `openFirewall = true` — direct LAN access, no nginx proxy

## Test plan

- [x] Deployed and running on nixnuc
- [x] Pre-commit hooks (nixfmt, deadnix, statix) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)