### PR TITLE
feat: add system-manager for home-manager-only hosts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,6 +315,22 @@
         "type": "github"
       }
     },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -325,6 +341,28 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "system-manager",
+          "userborn",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -368,7 +406,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -497,6 +535,29 @@
         "nixpkgs": [
           "simple-nixos-mailserver",
           "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_3": {
+      "inputs": {
+        "nixpkgs": [
+          "system-manager",
+          "userborn",
+          "pre-commit-hooks-nix",
           "nixpkgs"
         ]
       },
@@ -1068,6 +1129,34 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "system-manager",
+          "userborn",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_3",
+        "nixpkgs": [
+          "system-manager",
+          "userborn",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "private-flake": {
       "inputs": {
         "nixpkgs": [
@@ -1122,6 +1211,7 @@
         "simple-nixos-mailserver": "simple-nixos-mailserver",
         "sops-nix": "sops-nix",
         "statix": "statix",
+        "system-manager": "system-manager",
         "viscosity-cli": "viscosity-cli",
         "ytdlfin": "ytdlfin"
       }
@@ -1246,6 +1336,28 @@
         "type": "github"
       }
     },
+    "system-manager": {
+      "inputs": {
+        "flake-compat": "flake-compat_6",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "userborn": "userborn"
+      },
+      "locked": {
+        "lastModified": 1784579760,
+        "narHash": "sha256-7YKNfK0RQbUoYkjDI/EpTk76nDUiONJYuOxZnflx7tI=",
+        "owner": "numtide",
+        "repo": "system-manager",
+        "rev": "48d47346e0c6ad05b6c869ea92649c47723d1cfc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "system-manager",
+        "type": "github"
+      }
+    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -1306,6 +1418,21 @@
         "type": "github"
       }
     },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_2"
@@ -1342,6 +1469,35 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "userborn": {
+      "inputs": {
+        "flake-compat": [
+          "system-manager",
+          "flake-compat"
+        ],
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "system-manager",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1770377964,
+        "narHash": "sha256-q2pnlX2IW0kg80GLFnwWd/GigIpkuZnyKPLhrgJql3E=",
+        "owner": "jfroche",
+        "repo": "userborn",
+        "rev": "55c2cd7952c207a62736a5bbd9499ea73da18d24",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jfroche",
+        "ref": "system-manager",
+        "repo": "userborn",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,17 @@
 {
   description = "A flake for all my stuff";
-  # nixos-raspberrypi's own binary cache (pre-built vendor kernel/firmware
-  # for kiosk-gene-desk). Only inherited automatically when building *from
-  # their flake directly*, not when consumed as an input like here - hence
-  # declaring it ourselves. This is a build-time/client-side setting; it
-  # does not help kiosk-gene-desk's own future rebuilds once deployed -
-  # see its nix.settings.extra-substituters for that.
+  # Binary caches for flake inputs that don't propagate their own nixConfig
+  # when consumed as inputs rather than run directly.
   nixConfig = {
-    extra-substituters = [ "https://nixos-raspberrypi.cachix.org" ];
+    extra-substituters = [
+      # nixos-raspberrypi: pre-built vendor kernel/firmware for kiosk-gene-desk
+      "https://nixos-raspberrypi.cachix.org"
+      # numtide/system-manager
+      "https://cache.numtide.com"
+    ];
     extra-trusted-public-keys = [
       "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
     ];
   };
   inputs = {
@@ -156,6 +158,11 @@
     statix = {
       url = "github:astro/statix";
       inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    system-manager = {
+      url = "github:numtide/system-manager";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
 
     viscosity-cli = {
@@ -344,6 +351,16 @@
         };
       }; # end homeConfigurations
 
+      # System-level config for home-manager-only hosts (non-NixOS Linux)
+      systemConfigs = {
+        gene-x86_64-linux = localLib.mkSystemConfig {
+          system = "x86_64-linux";
+        };
+        gene-aarch64-linux = localLib.mkSystemConfig {
+          system = "aarch64-linux";
+        };
+      }; # end systemConfigs
+
       packages = forAllSystems (
         system:
         let
@@ -352,6 +369,7 @@
         import ./pkgs { inherit inputs pkgs; }
         // {
           deploy-rs = inputs.deploy-rs.packages.${system}.deploy-rs;
+          system-manager = inputs.system-manager.packages.${system}.default;
         }
       );
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,6 +4,7 @@ let
   mkDeployNode = import ./mkDeployNode.nix { inherit inputs; };
   mkHomeConfig = import ./mkHomeConfig.nix { inherit inputs; };
   mkNixosHost = import ./mkNixosHost.nix { inherit inputs; };
+  mkSystemConfig = import ./mkSystemConfig.nix { inherit inputs; };
   genebeanLib = {
     isDarwin = false;
     isHMOnly = false;
@@ -15,5 +16,6 @@ in
   inherit (mkDeployNode) mkDeployNode;
   inherit (mkHomeConfig) mkHomeConfig;
   inherit (mkNixosHost) mkNixosHost;
+  inherit (mkSystemConfig) mkSystemConfig;
   inherit genebeanLib;
 }

--- a/lib/mkSystemConfig.nix
+++ b/lib/mkSystemConfig.nix
@@ -1,0 +1,15 @@
+{ inputs, ... }:
+{
+  mkSystemConfig =
+    {
+      system,
+      username ? "gene",
+    }:
+    inputs.system-manager.lib.makeSystemConfig {
+      specialArgs = { inherit system username; };
+      modules = [
+        { nixpkgs.hostPlatform = system; }
+        ../modules/hosts/home-manager-only/system.nix
+      ];
+    };
+}

--- a/modules/genebean/home/programs/zsh.nix
+++ b/modules/genebean/home/programs/zsh.nix
@@ -154,7 +154,7 @@ in
         }
         # ─── HM-only (non-NixOS Linux) ────────────────────────────────────────
         // lib.optionalAttrs genebeanLib.isHMOnly {
-          nixup = "home-manager switch --flake ~/repos/dots#${username}-${system}";
+          nixup = "nix run ~/repos/dots#system-manager -- switch --sudo --flake ~/repos/dots#${username}-${system} && home-manager switch --flake ~/repos/dots#${username}-${system}";
         };
     };
   };

--- a/modules/hosts/home-manager-only/system.nix
+++ b/modules/hosts/home-manager-only/system.nix
@@ -1,0 +1,18 @@
+{ username, ... }:
+{
+  environment.etc."nix/nix.custom.conf".text = ''
+    trusted-users = root ${username}
+    extra-substituters = https://cache.flox.dev
+    extra-substituters = https://cache.numtide.com
+    extra-substituters = https://cache.thalheim.io
+    extra-substituters = https://cosmic.cachix.org/
+    extra-substituters = https://nix-community.cachix.org
+    extra-substituters = https://nixos-raspberrypi.cachix.org
+    extra-trusted-public-keys = cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc=
+    extra-trusted-public-keys = cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE=
+    extra-trusted-public-keys = flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs=
+    extra-trusted-public-keys = niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=
+    extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+    extra-trusted-public-keys = nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI=
+  '';
+}

--- a/modules/shared/home/general/default.nix
+++ b/modules/shared/home/general/default.nix
@@ -50,6 +50,7 @@
       lazydocker
       lazygit
       lua-language-server
+      mcp-nixos
       minicom
       mtr
       nil

--- a/pkgs/deploy-with-retry/default.nix
+++ b/pkgs/deploy-with-retry/default.nix
@@ -1,6 +1,6 @@
 { pkgs, inputs }:
 let
-  deploy-rs = inputs.deploy-rs.packages.${pkgs.system}.deploy-rs;
+  deploy-rs = inputs.deploy-rs.packages.${pkgs.stdenv.hostPlatform.system}.deploy-rs;
 in
 pkgs.writeShellApplication {
   name = "deploy-with-retry";

--- a/pkgs/nixdiff/default.nix
+++ b/pkgs/nixdiff/default.nix
@@ -2,6 +2,7 @@
 pkgs.writeShellApplication {
   name = "nixdiff";
   runtimeInputs = [
+    pkgs.diff-so-fancy
     pkgs.jq
     pkgs.nvd
   ];

--- a/pkgs/nixdiff/linux.sh
+++ b/pkgs/nixdiff/linux.sh
@@ -74,6 +74,31 @@ if [[ "${ID:-}" == "nixos" ]]; then
 
 else
   # Home Manager only
+
+  # system-manager diff — stderr (progress logs) flows to terminal; stdout is the store path
+  sm_result=$(nix run ~/repos/dots#system-manager -- build \
+    --flake ".#$(whoami)-$(uname -m)-linux")
+
+  echo ""
+  echo "=== System /etc changes ==="
+  sm_etc="$sm_result/etcFiles/etcFiles.json"
+  mapfile -t sm_targets < <(jq -r '.entries | to_entries[] | select(.value.text != null) | .key' "$sm_etc")
+  if [[ ${#sm_targets[@]} -eq 0 ]]; then
+    echo "(no text-mode /etc files managed)"
+  fi
+  for target in "${sm_targets[@]}"; do
+    new_text=$(jq -r --arg k "$target" '.entries[$k].text' "$sm_etc")
+    current_src="/etc/$target"
+    [[ -f "$current_src" ]] || current_src="/dev/null"
+    if diff -q "$current_src" <(printf '%s' "$new_text") &>/dev/null; then
+      echo "/etc/$target: no change"
+    else
+      diff -u "$current_src" <(printf '%s' "$new_text") \
+        --label "/etc/$target" --label "/etc/$target" \
+        | diff-so-fancy || true
+    fi
+  done
+
   home-manager build --flake ".#$(whoami)-$(uname -m)-linux"
 
   echo ""


### PR DESCRIPTION
## Summary

- Adds `numtide/system-manager` to declaratively manage system-level config on non-NixOS Linux hosts (Ubuntu laptop), filling the gap between home-manager (user-level) and NixOS (full system)
- Initial managed config: `/etc/nix/nix.custom.conf` — trusted-users plus the same substituters/keys as NixOS hosts; previously required manual steps after each reinstall
- `nixup` on HM-only hosts now runs `system-manager switch` first, then `home-manager switch`
- `nixdiff` on HM-only hosts now builds the system-manager config and diffs each managed `/etc` file (via jq + diff-so-fancy) before the home-manager diff
- Also includes: fix deprecated `pkgs.system` → `pkgs.stdenv.hostPlatform.system` in `deploy-with-retry`, and `mcp-nixos` added to general home packages

## First-time setup on a new host

```bash
# Remove any hand-written nix.custom.conf, then activate
sudo rm /etc/nix/nix.custom.conf
nix run ~/repos/dots#system-manager -- switch --sudo --flake ~/repos/dots#gene-x86_64-linux
```

## Test plan

- [x] `system-manager switch` activated successfully on rainbow-planet
- [x] `/etc/nix/nix.custom.conf` is now a store symlink with correct content
- [x] `nixdiff` shows system /etc diff before HM package diff
- [x] `nixup` alias runs system-manager then home-manager in sequence
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)