### PR TITLE
feat: consolidate nix binary caches into genebean module with system-manager support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -192,6 +192,7 @@
       darwinModules.genebean = ./modules/genebean/darwin;
       homeManagerModules.genebean = ./modules/genebean/home;
       nixosModules.genebean = ./modules/genebean/nixos;
+      systemManagerModules.genebean = ./modules/genebean/system-manager;
 
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
 

--- a/lib/mkSystemConfig.nix
+++ b/lib/mkSystemConfig.nix
@@ -9,6 +9,7 @@
       specialArgs = { inherit system username; };
       modules = [
         { nixpkgs.hostPlatform = system; }
+        inputs.self.systemManagerModules.genebean
         ../modules/hosts/home-manager-only/system.nix
       ];
     };

--- a/modules/genebean/README.md
+++ b/modules/genebean/README.md
@@ -1,0 +1,231 @@
+# modules/genebean
+
+Reusable, option-driven modules that abstract platform differences behind a
+single Home Manager interface. The philosophy is Puppet-like: declare what you
+want once in Home Manager, and the module figures out how to deliver it on each
+platform (NixOS, macOS/nix-darwin, Ubuntu/HM-only).
+
+Consumers set options. They never import module files directly.
+
+---
+
+## Directory Layout
+
+```
+modules/genebean/
+  data/           — pure Nix data (no module system); imported by any layer that needs it
+  home/           — Home Manager (all platforms) — always the consumer declaration point
+  darwin/         — nix-darwin system layer (macOS only) — e.g. Homebrew casks
+  nixos/          — NixOS system layer (NixOS only) — e.g. system services, polkit
+  system-manager/ — system-manager layer (HM-only Linux hosts) — e.g. /etc files
+```
+
+Each module layer has a `default.nix` that is a plain `{ imports = [ ... ]; }` list.
+Adding a module means creating the file and one line in `default.nix` — no
+changes to flake outputs or lib helpers are needed.
+
+### How the module layers are loaded
+
+| Layer | Loaded by | Via |
+|---|---|---|
+| `home/` | all builders | `homeManagerModules.genebean` in every lib helper |
+| `darwin/` | `mkDarwinHost` only | `darwinModules.genebean` as a nix-darwin system module |
+| `nixos/` | `mkNixosHost` only | `nixosModules.genebean` as a NixOS system module |
+| `system-manager/` | `mkSystemConfig` only | `systemManagerModules.genebean` as a system-manager module |
+
+Home Manager is always the consumer-facing layer. The other layers are
+implementation details that fire automatically — the user only ever sets
+the home-manager option.
+
+### The `data/` directory
+
+`data/` holds plain Nix attrsets — no module system, no options, no `lib` or
+`pkgs`. Think Puppet Hiera: structured data that any module layer can import
+directly and use however its module system requires.
+
+```nix
+# data/nix-caches.nix — just an attrset
+{
+  substituters = [ "https://cache.example.com" ];
+  trustedPublicKeys = [ "example.com-1:..." ];
+}
+```
+
+Use `data/` when the same values need to reach multiple module systems that
+cannot share options (e.g. NixOS `nix.settings`, nix-darwin `nix.settings`,
+and system-manager `environment.etc`). Defining the data once and importing it
+avoids drift between layers.
+
+Candidates for `data/`:
+- Fleet-wide Nix binary caches (`nix-caches.nix`) — already here
+- Port/service registry (`ports.nix`) — currently in `nixos/`, candidate for future move
+
+---
+
+## Namespacing
+
+| Namespace | Use for | Example |
+|---|---|---|
+| `genebean.programs.<name>` | User-facing applications | `genebean.programs.ghostty` |
+| `genebean.services.<name>` | Background services | `genebean.services.tailscale` |
+| `genebean.<name>` | Meta / environment (desktop, kiosk hardware) | `genebean.plasma` |
+
+Top-level options like `genebean.plasma` and `genebean.kiosk-hardware` don't
+fit neatly into programs or services — they configure entire environments rather
+than individual pieces of software.
+
+---
+
+## `genebeanLib` Flags
+
+Passed as `extraSpecialArgs` to every Home Manager module. All default `false`;
+one is set `true` per builder:
+
+| Flag | True in | Use for |
+|---|---|---|
+| `isNixOS` | `mkNixosHost` | NixOS-specific defaults and guards |
+| `isDarwin` | `mkDarwinHost` | macOS-specific defaults and guards |
+| `isHMOnly` | `mkHomeConfig` | Ubuntu / HM-only hosts |
+
+Set explicitly per builder (not via `builtins.pathExists`) to keep evaluation
+pure.
+
+---
+
+## Patterns
+
+### 1. Simple enable stub
+
+The home module declares the option; all install work happens in the companions.
+
+```nix
+{ lib, ... }:
+{
+  options.genebean.programs.foo = {
+    enable = lib.mkEnableOption "Foo";
+  };
+}
+```
+
+### 2. Self-contained with platform guards
+
+The home module handles everything, gating platform-specific config with
+`lib.optionalAttrs` and `genebeanLib` flags.
+
+```nix
+config = lib.mkIf cfg.enable (
+  lib.optionalAttrs (!genebeanLib.isDarwin) {
+    services.flatpak.packages = [ "org.example.Foo" ];
+  }
+);
+```
+
+### 3. `linuxInstallMethod` enum
+
+For apps available as both a Flatpak and a Nix package on Linux.
+
+```nix
+linuxInstallMethod = lib.mkOption {
+  type    = lib.types.enum [ "flatpak" "nixpkgs" "none" ];
+  default = "flatpak";
+};
+```
+
+The module then acts on the choice rather than installing via both paths.
+
+### 4. Dual install flags
+
+For apps that have separate Homebrew and Nix install paths (e.g. Ghostty).
+
+```nix
+installViaHomebrew = lib.mkOption {
+  type    = lib.types.bool;
+  default = pkgs.stdenv.isDarwin;
+};
+installViaNix = lib.mkOption {
+  type    = lib.types.bool;
+  default = genebeanLib.isNixOS;
+};
+```
+
+### 5. Darwin companion
+
+When macOS needs a system-level action (Homebrew cask, MAS app), the companion
+reads the home-manager option:
+
+```nix
+# darwin/programs/foo.nix
+{ config, lib, username, ... }:
+{
+  config = lib.mkIf config.home-manager.users.${username}.genebean.programs.foo.installViaHomebrew {
+    homebrew.casks = [ "foo" ];
+  };
+}
+```
+
+### 6. NixOS companion
+
+When NixOS needs a system-level action (service, polkit, system program), the
+companion reads the same home-manager option path:
+
+```nix
+# nixos/programs/foo.nix
+{ config, lib, username, ... }:
+{
+  config = lib.mkIf config.home-manager.users.${username}.genebean.programs.foo.enable {
+    programs.foo.enable = true;
+  };
+}
+```
+
+### 7. Data-driven cross-layer module
+
+When the same values must reach multiple module systems that cannot share
+options (e.g. NixOS, nix-darwin, and system-manager all need the same cache
+list but set it via different options), put the data in `data/` and import it
+in each layer:
+
+```nix
+# nixos/nix-caches.nix and darwin/nix-caches.nix
+let caches = import ../data/nix-caches.nix; in
+{ ... }:
+{ nix.settings = { extra-substituters = caches.substituters; ... }; }
+
+# system-manager/nix-caches.nix
+let caches = import ../data/nix-caches.nix; in
+{ ... }:
+{ environment.etc."nix/nix.conf.d/genebean-caches.conf".text =
+    builtins.concatStringsSep "\n" (
+      map (s: "extra-substituters = ${s}") caches.substituters
+      ++ map (k: "extra-trusted-public-keys = ${k}") caches.trustedPublicKeys
+    ) + "\n"; }
+```
+
+Do **not** expose data-driven cross-layer values as Home Manager options — the
+system-manager layer cannot read HM options, so duplicating them there would
+create drift.
+
+---
+
+## Adding a New Module
+
+1. **Home layer** — `home/programs/<name>.nix` (or `services/` as appropriate):
+   define `options.genebean.programs.<name>.*` and
+   `config = lib.mkIf cfg.enable { ... }`. Add to `home/default.nix`.
+
+2. **Darwin companion** (only if a system-level macOS action is needed) —
+   `darwin/programs/<name>.nix`. Add to `darwin/default.nix`.
+
+3. **NixOS companion** (only if a system-level NixOS action is needed) —
+   `nixos/programs/<name>.nix`. Add to `nixos/default.nix`.
+
+4. **system-manager module** (only if a system-level action is needed on
+   HM-only Linux hosts) — `system-manager/<name>.nix`. Add to
+   `system-manager/default.nix`.
+
+5. **Call site** — set `genebean.programs.<name>.enable = true` in the relevant
+   shared module or host file. No imports needed.
+
+Not every module needs all layers. Most GUI apps have a home layer and a darwin
+companion; NixOS/system-manager layers are only needed when the system layer
+must act (e.g. enabling a service, writing an `/etc` file).

--- a/modules/genebean/README.md
+++ b/modules/genebean/README.md
@@ -205,6 +205,24 @@ Do **not** expose data-driven cross-layer values as Home Manager options — the
 system-manager layer cannot read HM options, so duplicating them there would
 create drift.
 
+### The `nix.conf.d/` and `nix.custom.conf` relationship
+
+Determinate Nix only reads `/etc/nix/nix.custom.conf` via an explicit `!include`
+in its generated `nix.conf`. It does **not** auto-read `/etc/nix/nix.conf.d/`.
+
+When a system-manager module writes a file under `nix/nix.conf.d/`, you must
+add a corresponding `include` line in `nix.custom.conf` so Determinate Nix
+picks it up. Use `include` (without `!`) so nix does not error if the file is
+absent before system-manager has activated:
+
+```
+# in nix.custom.conf
+include /etc/nix/nix.conf.d/genebean-caches.conf
+```
+
+`modules/hosts/home-manager-only/system.nix` owns `nix.custom.conf` and
+carries one include line per system-manager module that writes to `nix.conf.d/`.
+
 ---
 
 ## Adding a New Module

--- a/modules/genebean/darwin/default.nix
+++ b/modules/genebean/darwin/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./nix-caches.nix
     ./programs/angry-ip-scanner.nix
     ./programs/askpass.nix
     ./programs/boinc.nix

--- a/modules/genebean/darwin/nix-caches.nix
+++ b/modules/genebean/darwin/nix-caches.nix
@@ -1,0 +1,9 @@
+let
+  caches = import ../data/nix-caches.nix;
+in
+{
+  nix.settings = {
+    extra-substituters = caches.substituters;
+    extra-trusted-public-keys = caches.trustedPublicKeys;
+  };
+}

--- a/modules/genebean/data/nix-caches.nix
+++ b/modules/genebean/data/nix-caches.nix
@@ -1,0 +1,18 @@
+{
+  substituters = [
+    "https://cache.flox.dev"
+    "https://cache.numtide.com"
+    "https://cache.thalheim.io"
+    "https://cosmic.cachix.org/"
+    "https://nix-community.cachix.org"
+    "https://nixos-raspberrypi.cachix.org"
+  ];
+  trustedPublicKeys = [
+    "cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc="
+    "cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE="
+    "flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs="
+    "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
+  ];
+}

--- a/modules/genebean/nixos/default.nix
+++ b/modules/genebean/nixos/default.nix
@@ -3,6 +3,7 @@
     ./kiosk-hardware.nix
     ./plasma.nix
     ./ports.nix
+    ./nix-caches.nix
     ./programs/askpass.nix
     ./programs/boinc.nix
     ./programs/firefox.nix

--- a/modules/genebean/nixos/nix-caches.nix
+++ b/modules/genebean/nixos/nix-caches.nix
@@ -1,0 +1,9 @@
+let
+  caches = import ../data/nix-caches.nix;
+in
+{
+  nix.settings = {
+    extra-substituters = caches.substituters;
+    extra-trusted-public-keys = caches.trustedPublicKeys;
+  };
+}

--- a/modules/genebean/system-manager/default.nix
+++ b/modules/genebean/system-manager/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./nix-caches.nix
+  ];
+}

--- a/modules/genebean/system-manager/nix-caches.nix
+++ b/modules/genebean/system-manager/nix-caches.nix
@@ -8,4 +8,19 @@ in
       ++ map (k: "extra-trusted-public-keys = ${k}") caches.trustedPublicKeys
     )
     + "\n";
+
+  # Restart nix-daemon whenever the cache config file changes so the new
+  # substituters are picked up without requiring a manual intervention.
+  systemd.paths.nix-daemon-reload = {
+    wantedBy = [ "system-manager.target" ];
+    pathConfig.PathChanged = "/etc/nix/nix.conf.d/genebean-caches.conf";
+  };
+
+  systemd.services.nix-daemon-reload = {
+    description = "Restart nix-daemon after cache config change";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "/usr/bin/systemctl restart nix-daemon.service";
+    };
+  };
 }

--- a/modules/genebean/system-manager/nix-caches.nix
+++ b/modules/genebean/system-manager/nix-caches.nix
@@ -1,0 +1,11 @@
+let
+  caches = import ../data/nix-caches.nix;
+in
+{
+  environment.etc."nix/nix.conf.d/genebean-caches.conf".text =
+    builtins.concatStringsSep "\n" (
+      map (s: "extra-substituters = ${s}") caches.substituters
+      ++ map (k: "extra-trusted-public-keys = ${k}") caches.trustedPublicKeys
+    )
+    + "\n";
+}

--- a/modules/hosts/darwin/default.nix
+++ b/modules/hosts/darwin/default.nix
@@ -80,18 +80,6 @@
         "flakes"
         "nix-command"
       ];
-      extra-substituters = [
-        "https://cache.flox.dev"
-        "https://cache.numtide.com"
-        "https://cache.thalheim.io"
-        "https://nix-community.cachix.org"
-      ];
-      extra-trusted-public-keys = [
-        "cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc="
-        "flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs="
-        "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
-        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      ];
       trusted-users = [
         "@admin"
         "${username}"

--- a/modules/hosts/home-manager-only/system.nix
+++ b/modules/hosts/home-manager-only/system.nix
@@ -2,5 +2,9 @@
 {
   environment.etc."nix/nix.custom.conf".text = ''
     trusted-users = root ${username}
+
+    # Add an include line here for each genebean system-manager module that
+    # writes a file under /etc/nix/nix.conf.d/ so Determinate Nix picks it up.
+    include /etc/nix/nix.conf.d/genebean-caches.conf
   '';
 }

--- a/modules/hosts/home-manager-only/system.nix
+++ b/modules/hosts/home-manager-only/system.nix
@@ -2,17 +2,5 @@
 {
   environment.etc."nix/nix.custom.conf".text = ''
     trusted-users = root ${username}
-    extra-substituters = https://cache.flox.dev
-    extra-substituters = https://cache.numtide.com
-    extra-substituters = https://cache.thalheim.io
-    extra-substituters = https://cosmic.cachix.org/
-    extra-substituters = https://nix-community.cachix.org
-    extra-substituters = https://nixos-raspberrypi.cachix.org
-    extra-trusted-public-keys = cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc=
-    extra-trusted-public-keys = cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE=
-    extra-trusted-public-keys = flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs=
-    extra-trusted-public-keys = niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=
-    extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
-    extra-trusted-public-keys = nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI=
   '';
 }

--- a/modules/hosts/nixos/default.nix
+++ b/modules/hosts/nixos/default.nix
@@ -56,22 +56,6 @@
       "flakes"
       "nix-command"
     ];
-    extra-substituters = [
-      "https://cache.flox.dev"
-      "https://cache.numtide.com"
-      "https://cache.thalheim.io"
-      "https://cosmic.cachix.org/"
-      "https://nix-community.cachix.org"
-      "https://nixos-raspberrypi.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc="
-      "cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE="
-      "flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs="
-      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
-      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
-    ];
     trusted-users = [ "${username}" ];
   };
 

--- a/pkgs/nixdiff/linux.sh
+++ b/pkgs/nixdiff/linux.sh
@@ -99,6 +99,68 @@ else
     fi
   done
 
+  # Systemd unit diff — system-manager manages units via a source directory, not text,
+  # so they are not captured by the text-file loop above.
+  sm_systemd_source=$(jq -r '.entries["systemd/system"].source // empty' "$sm_etc")
+  if [[ -n "$sm_systemd_source" ]]; then
+    echo ""
+    echo "=== System-manager systemd unit changes ==="
+    new_units=$(readlink -f "$sm_systemd_source/systemd/system")
+
+    sm_profile="/nix/var/nix/profiles/system-manager-profiles/system-manager"
+    if [[ -L "$sm_profile" ]]; then
+      old_etc=$(readlink -f "$sm_profile")/etcFiles/etcFiles.json
+      old_source=$(jq -r '.entries["systemd/system"].source // empty' "$old_etc" 2>/dev/null)
+      old_units=$(readlink -f "$old_source/systemd/system" 2>/dev/null || echo "")
+    else
+      old_units=""
+    fi
+
+    # List only unit files (symlinks/files), not .wants/.requires dirs
+    list_units() {
+      local f
+      for f in "$1"/*; do
+        [[ -e "$f" ]] || continue
+        [[ -d "$f" ]] && continue
+        printf '%s\n' "${f##*/}"
+      done | sort
+    }
+
+    if [[ -z "$old_units" || ! -d "$old_units" ]]; then
+      echo "(no previous profile — all units are new)"
+      list_units "$new_units" | while IFS= read -r unit; do
+        echo "  + $unit"
+      done
+    else
+      any_unit_change=false
+
+      while IFS= read -r unit; do
+        [[ -n "$unit" ]] && echo "  + $unit" && any_unit_change=true
+      done < <(comm -13 <(list_units "$old_units") <(list_units "$new_units"))
+
+      while IFS= read -r unit; do
+        [[ -n "$unit" ]] && echo "  - $unit" && any_unit_change=true
+      done < <(comm -23 <(list_units "$old_units") <(list_units "$new_units"))
+
+      while IFS= read -r unit; do
+        old_file=$(readlink -f "$old_units/$unit" 2>/dev/null || echo "")
+        new_file=$(readlink -f "$new_units/$unit" 2>/dev/null || echo "")
+        if [[ -f "$old_file" && -f "$new_file" ]]; then
+          if ! diff -q "$old_file" "$new_file" &>/dev/null; then
+            diff -u "$old_file" "$new_file" \
+              --label "$unit (current)" --label "$unit (new)" \
+              | diff-so-fancy || true
+            any_unit_change=true
+          fi
+        fi
+      done < <(comm -12 <(list_units "$old_units") <(list_units "$new_units"))
+
+      if [[ "$any_unit_change" != "true" ]]; then
+        echo "(no changes)"
+      fi
+    fi
+  fi
+
   home-manager build --flake ".#$(whoami)-$(uname -m)-linux"
 
   echo ""


### PR DESCRIPTION
## Summary

- Add `modules/genebean/data/nix-caches.nix` as a single source of truth for all binary cache substituters and trusted public keys (Puppet Hiera pattern — pure Nix attrset, no module system)
- Add `modules/genebean/nixos/nix-caches.nix` and `modules/genebean/darwin/nix-caches.nix` that import the data file and wire it into `nix.settings`
- Add `modules/genebean/system-manager/` layer (new) with `nix-caches.nix` that writes `/etc/nix/nix.conf.d/genebean-caches.conf` for HM-only Linux hosts; includes systemd path/service units that restart `nix-daemon.service` automatically when the cache config changes
- Update `modules/hosts/home-manager-only/system.nix` to add an `include` directive in `nix.custom.conf` for the conf.d file (Determinate Nix does not auto-read `nix.conf.d/`; explicit include required)
- Remove the now-duplicate cache lists from `modules/hosts/nixos/default.nix` and `modules/hosts/darwin/default.nix`
- Wire `systemManagerModules.genebean` into `flake.nix` and `lib/mkSystemConfig.nix`
- Add `modules/genebean/README.md` documenting the full module architecture: data/, home/, darwin/, nixos/, system-manager/ layers, namespacing, genebeanLib flags, all module patterns, and the nix.conf.d / nix.custom.conf relationship
- Enhance `pkgs/nixdiff/linux.sh` to show systemd unit additions/removals/changes from system-manager (previously only text-mode `/etc` files were shown)

## Test plan

- [x] `nix run .#nixdiff` builds cleanly (shellcheck passes) and shows systemd unit changes in output
- [x] `nixup` on rainbow-planet activates cleanly — system-manager wrote new etc files and loaded `nix-daemon-reload.path` / `nix-daemon-reload.service` without error
- [ ] Verify `nix-daemon.service` actually restarts when cache config is touched (path unit fires)
- [x] Verify Darwin build still evaluates cleanly (no regression in `darwin/nix-caches.nix`)
- [x] Verify NixOS host still evaluates cleanly (no regression in `nixos/nix-caches.nix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)