### PR TITLE
feat: add dnclient for defined.net managed Nebula VPN

### DIFF
--- a/lib/nixpkgs-settings.nix
+++ b/lib/nixpkgs-settings.nix
@@ -10,6 +10,7 @@
     };
     overlays = [
       (final: prev: {
+        dnclient = prev.callPackage ../pkgs/dnclient { };
         nixdiff = prev.callPackage ../pkgs/nixdiff { };
       })
     ];

--- a/modules/genebean/nixos/default.nix
+++ b/modules/genebean/nixos/default.nix
@@ -11,6 +11,7 @@
     ./programs/thunderbird.nix
     ./programs/xfce4-terminal.nix
     ./services/chromium-kiosk.nix
+    ./services/dnclient.nix
     ./services/flatpak.nix
     ./services/kiosk-backups.nix
     ./services/restic.nix

--- a/modules/genebean/nixos/services/dnclient.nix
+++ b/modules/genebean/nixos/services/dnclient.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.genebean.services.dnclient;
+in
+{
+  options.genebean.services.dnclient = {
+    enable = lib.mkEnableOption "dnclient managed Nebula VPN";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.dnclient ];
+
+    systemd.services.dnclient = {
+      description = "DNClient Nebula VPN";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.dnclient}/bin/dnclient run";
+        Restart = "always";
+        RestartSec = "5s";
+      };
+    };
+  };
+}

--- a/modules/hosts/nixos/nixnuc/default.nix
+++ b/modules/hosts/nixos/nixnuc/default.nix
@@ -114,6 +114,8 @@ in
     mtr.enable = true;
   };
 
+  genebean.services.dnclient.enable = true;
+
   # List services that you want to enable:
   services = {
     atuin = {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,10 +1,16 @@
 { inputs, pkgs }:
 let
   deploy-with-retry = pkgs.callPackage ./deploy-with-retry { inherit inputs; };
+  dnclient = pkgs.callPackage ./dnclient { };
   nixdiff = pkgs.callPackage ./nixdiff { };
   rpi4-installer = pkgs.callPackage ./rpi4-installer { inherit inputs; };
 in
 {
-  inherit deploy-with-retry nixdiff rpi4-installer;
+  inherit
+    deploy-with-retry
+    dnclient
+    nixdiff
+    rpi4-installer
+    ;
   default = nixdiff;
 }

--- a/pkgs/dnclient/default.nix
+++ b/pkgs/dnclient/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+let
+  version = "0.9.6";
+in
+stdenv.mkDerivation {
+  pname = "dnclient";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://dl.defined.net/10c23c2d/v${version}/linux/amd64/dnclient";
+    hash = "sha256-Z/uvC89Dt8r5crkahkUhrCnSj7Ae8N54B5TZvgchtPA=";
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm755 $src $out/bin/dnclient
+  '';
+
+  meta = {
+    description = "Managed Nebula VPN client from Defined Networking";
+    homepage = "https://defined.net";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.unfree;
+    mainProgram = "dnclient";
+  };
+}


### PR DESCRIPTION
## Summary

- Packages `dnclient` v0.9.6 (closed-source static Go binary from defined.net) as a custom derivation in `pkgs/dnclient/`
- Overlays it into nixpkgs via `lib/nixpkgs-settings.nix` so NixOS modules can reference `pkgs.dnclient`
- Adds a NixOS service module at `modules/genebean/nixos/services/dnclient.nix` behind an opt-in `genebean.services.dnclient.enable` flag
- Enables it on nixnuc

## Test plan

- [x] `nix build .#dnclient` succeeds
- [x] `nix eval .#nixosConfigurations.nixnuc.config.genebean.services.dnclient.enable` returns `true`
- [x] `sudo nixos-rebuild switch --flake .#nixnuc` succeeded on nixnuc
- [x] `sudo systemctl start dnclient` + `sudo dnclient enroll -code <CODE>` enrolled successfully
- [x] `ip a show defined1` confirms the Nebula interface is up with an IPv6 address

## Notes

Enrollment is a one-time manual step per host: `sudo dnclient enroll -code <CODE>` (get the code from the defined.net dashboard). After that, dnclient handles cert rotation automatically via the defined.net API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL9di9snFd1GGxF3G9YPsy