### PR TITLE
fix: restore GUI apps on home-manager-only hosts

### DIFF
--- a/lib/mkHomeConfig.nix
+++ b/lib/mkHomeConfig.nix
@@ -31,6 +31,7 @@ in
         ../modules/hosts/home-manager-only
         ../modules/hosts/home-manager-only/home-${username}.nix
         ../modules/shared/home/general
+        ../modules/shared/home/general/all-gui.nix
 
         {
           home = {


### PR DESCRIPTION
## Summary

- `lib/mkHomeConfig.nix` now imports `all-gui.nix` so HM-only hosts get the full GUI app set

## Background

`modules/shared/linux/flatpaks.nix` previously declared the flatpak package list and was imported directly in `mkHomeConfig`. PR #682 migrated each app into a `genebean.programs.*` module and enabled them via `all-gui.nix` — but `all-gui.nix` was only wired up on bigboy, not in `mkHomeConfig`. Combined with `uninstallUnmanaged = true` in `genebean.services.flatpak`, the next `home-manager switch` on the HM-only (Ubuntu) host removed all flatpaks.

## Test plan

- [x] `home-manager switch` on HM-only x86 Ubuntu host — verify Signal and other flatpaks are installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)