### PR TITLE
chore: nix flake update + fix deprecated stdenv platform checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,7 @@ available in any home-manager module:
 | Helper | Value | Use for |
 |---|---|---|
 | `genebeanLib.isNixOS` | `true` in `mkNixosHost`, `false` elsewhere | NixOS vs other Linux |
-| `pkgs.stdenv.isDarwin` | stdlib | macOS detection |
+| `pkgs.stdenv.hostPlatform.isDarwin` | stdlib | macOS detection |
 
 `genebeanLib.isNixOS` is set explicitly per builder (not via `builtins.pathExists`)
 to keep evaluation pure. Use it as the `default` for platform-varying options:

--- a/flake.lock
+++ b/flake.lock
@@ -35,16 +35,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1785710351,
-        "narHash": "sha256-DTL5T9+HlblsnXCEdxRpEo/2NBHD3t48BS7r+PTf090=",
+        "lastModified": 1788591592,
+        "narHash": "sha256-NbwVKwKLFl0oXub7oPjvmDaOygCtV2oboeKTu4xXFTk=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "7b0f22a4ab77567edef114c8dfc423fb96e2fbaa",
+        "rev": "08e85c4e42f5d8f1ea17c36cb59cf61c2ccb26c3",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.15",
+        "ref": "6.0.22",
         "repo": "brew",
         "type": "github"
       }
@@ -57,11 +57,11 @@
         "onchg": "onchg"
       },
       "locked": {
-        "lastModified": 1786284790,
-        "narHash": "sha256-fNUgCpm1DVbX2JoSGjsDOJmVfJ0Lr+9yduEHm+Wm3RI=",
+        "lastModified": 1787629804,
+        "narHash": "sha256-2ZcblR6Wy0NQWbogbqDbszr7shfKPQFG0ftnFrbAOaM=",
         "owner": "aksiksi",
         "repo": "compose2nix",
-        "rev": "7a29ae0ee08184123d03a867d7daf75bb4e6c8c1",
+        "rev": "49ddd9f59753183d4072a7fe281e63fee53ba0ee",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785105427,
-        "narHash": "sha256-2fBillHndQn/eHOAkDttCxRygc6f6BzhRzIY4q0TKMg=",
+        "lastModified": 1788642790,
+        "narHash": "sha256-+VBvYzzYwxouEri/PHkRBfj54WvmBvr5nAz6Efdh2sk=",
         "owner": "astro",
         "repo": "deadnix",
-        "rev": "4fc88a77cf436e9671dea4b28d1aab37a75f6ea2",
+        "rev": "c75211a73610f216a20e846eba87de019b2f70b9",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1786361680,
-        "narHash": "sha256-IxaZkb9rCGEZ+yGndxKXONeIEcKMzoFUsvLTB5G/caw=",
+        "lastModified": 1788879443,
+        "narHash": "sha256-qb9sL86UCUEd3SYAda4ItN1NV0vhMSdbpA64WckvVI0=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "16901271e5b30b591e56f7a84f25f186fb20f3e1",
+        "rev": "414ac5f35d79aabe5a0bf52451d8cf61eadf6c88",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1785627969,
-        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
         "type": "github"
       },
       "original": {
@@ -430,11 +430,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782361692,
-        "narHash": "sha256-0diVbc02yjbjnqsnVG6yWZWEIqUvR3Odm6n1EHgJcbQ=",
+        "lastModified": 1789146858,
+        "narHash": "sha256-EXnKEI1JvpOifIZ0b8Pwl5RINR96EeFOXdAZUQc0qOw=",
         "owner": "genebean",
         "repo": "neovim-flake",
-        "rev": "e3fdf0b78617cf18bc5074a676b3d1873bcff23c",
+        "rev": "5e5b46d5ad2bd6ac1e849cfaa06a92a6440471be",
         "type": "github"
       },
       "original": {
@@ -579,11 +579,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785119570,
-        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
+        "lastModified": 1788642154,
+        "narHash": "sha256-sPpQFVaFTDqO/4vvCAhuAhqTgqN/ygu+9eJcs5eB0js=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
+        "rev": "fd0956c99c41ae3c13a73a638f1f7e963aebc4ab",
         "type": "github"
       },
       "original": {
@@ -625,11 +625,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785985959,
-        "narHash": "sha256-PHKMqGwfwniAHlbuZl5CUg1bEoSeIGUJHXwzHpHOQeA=",
+        "lastModified": 1788505976,
+        "narHash": "sha256-8OQB4IYOfePVk+rDyxg623inTP9R1DqSdwz5afbpP0w=",
         "owner": "numtide",
         "repo": "nix-auth",
-        "rev": "d43fad3e926493db26d915aba7c0284606e07782",
+        "rev": "575338159cc1a196e931ee96ff0bb94b90f42f7a",
         "type": "github"
       },
       "original": {
@@ -679,11 +679,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1786217209,
-        "narHash": "sha256-rusAj5QBnbSwXG6csns6dwxTeCOGRcj08VmlnhUQ6ZY=",
+        "lastModified": 1788981439,
+        "narHash": "sha256-fEaFq0XgpgWFPLfpq1UK4/8ylHd2T0+fo6O3hKz1LUM=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "486357ea434dc0061ea52121ff99b1d33096c811",
+        "rev": "09a921d0181146cf6163ec2cc1db7b6fd539a885",
         "type": "github"
       },
       "original": {
@@ -739,11 +739,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783265394,
-        "narHash": "sha256-cq4YfNFGYzp0NItZP8tEC7xUI8OSgY4fj75AU/NSaPM=",
+        "lastModified": 1786747096,
+        "narHash": "sha256-9QqhmaLVsPhKdMSBaWKjDqeGRn8G4ov4cVuZ6JFwXbo=",
         "owner": "numtide",
         "repo": "nix-vm-test",
-        "rev": "1a587212d2ac8b669c6c32499015f996506b6ba5",
+        "rev": "c8781a0ea2d8417506fff7722eae5a6316461212",
         "type": "github"
       },
       "original": {
@@ -760,11 +760,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775724285,
-        "narHash": "sha256-/ukfzDYzcuz7i+unH7XioPS3Acam6FC935XsOCaJDmY=",
+        "lastModified": 1788981141,
+        "narHash": "sha256-7xWS16u13YGlRNKWaAPzRbEyh4OLOXJe31k7h4AnXNU=",
         "owner": "BirdeeHub",
         "repo": "nix-wrapper-modules",
-        "rev": "d79d2f910dd0d8bffd11113865923199cb304f86",
+        "rev": "1db3c116a6aa61823f8d8f3c47c306846428fc54",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1786009700,
-        "narHash": "sha256-bRgr9BVDzJSBorOb2kURTx1nvK/JM6TewNXE6wDl9Sk=",
+        "lastModified": 1788938537,
+        "narHash": "sha256-ooFA+3//Y9bpyFjVwTvPegsWngEoQ0pGj+2DJ5cVyJ0=",
         "owner": "nix-community",
         "repo": "nixos-anywhere",
-        "rev": "036bd2423203b1432f36621404289832183cfecd",
+        "rev": "9df41112343713520ba071674cf8e45e91c25845",
         "type": "github"
       },
       "original": {
@@ -834,11 +834,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785232496,
-        "narHash": "sha256-65EQYIRRpTdpH8lUiB6Mvo5uBkG60aBIzAJuALfx+O0=",
+        "lastModified": 1788942796,
+        "narHash": "sha256-CLoJCCRi9sogsyGXYn8rOCWBLKAntfKUB9Rli/YXgEY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2e790b0a6be8ec2b76174ac0931b8ff11919ec98",
+        "rev": "83bbc895120516d6e86885a188c04beced6535d9",
         "type": "github"
       },
       "original": {
@@ -860,11 +860,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785407732,
-        "narHash": "sha256-iv6OYbZgMqvudEFB4LvhpZDHyNqD+lx0WubIk6BdAVg=",
+        "lastModified": 1788431493,
+        "narHash": "sha256-njqRK/q34pSB9ueddXANIRDx0btXPSsAUFFf8mSO840=",
         "owner": "nix-community",
         "repo": "nixos-images",
-        "rev": "e2a34c0ce9dcbb5169f2a233b49211f5f30b7d69",
+        "rev": "82517d9a537aad897a6bc872f511c19bbe8bdf03",
         "type": "github"
       },
       "original": {
@@ -907,11 +907,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1786353041,
-        "narHash": "sha256-TVf9e3UZ+fScRSoakLYIiJU84p24QxOhhJvL8G5iJGw=",
+        "lastModified": 1788658752,
+        "narHash": "sha256-gNPe4RUYMNTMIyxDDeUCTBUcmUFGUpHybC7IZrc6Fas=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "9a2bb77b1d7a953dbf7d278370f79bea66619f48",
+        "rev": "1c639b2e8c824704c5abfd772493392d9e6a261a",
         "type": "github"
       },
       "original": {
@@ -938,11 +938,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1785031560,
-        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "lastModified": 1788057806,
+        "narHash": "sha256-DTQSMxzDWmT0zhguthvegnVkn7CFqGCv4IHCzk5ZUpM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "rev": "596e2e3940e09b2abbeb03f75fa1828c57fcd72c",
         "type": "github"
       },
       "original": {
@@ -953,11 +953,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1786098110,
-        "narHash": "sha256-shi1tjDhCGGd0kIgVPNY03V8NBWSTzhMSFDb7IqSoec=",
+        "lastModified": 1789012029,
+        "narHash": "sha256-1CBkBf+Nhggykzlx0jvXrj5rk20btl+tK8Fa8Ml/BL4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "afb4584a80bbf779ce0f691509ff902d188c2b3d",
+        "rev": "d5dfd8e6716dde34398bc14bc87c10dece9c8c68",
         "type": "github"
       },
       "original": {
@@ -985,11 +985,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1786089803,
-        "narHash": "sha256-ZuvZfVW2tB5tXYEcpcfhVXB3N4OhdZLOqOviy4OD4b4=",
+        "lastModified": 1788584326,
+        "narHash": "sha256-Fd3OB8J9JhgliQwOKcqx4M672CInxi1I5VnwsaXeSQo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee48b147c18c7de1e6ec97dc74792be42724bed1",
+        "rev": "6713828a351efa628b025a1adf7f43cbf8597513",
         "type": "github"
       },
       "original": {
@@ -1001,11 +1001,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1786313170,
-        "narHash": "sha256-9BG7OgUWdu0ONDO5X2q6+K4bsuBITkX/3W4nNJu1Ito=",
+        "lastModified": 1788921488,
+        "narHash": "sha256-8+xWRxEkD6l217cIUdRxfeUGS9lQX0hVtUuNVsBaDzk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d",
+        "rev": "6aefcda9401be8acc2b74244fb3b37520ea1f0a8",
         "type": "github"
       },
       "original": {
@@ -1256,11 +1256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783174389,
-        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "lastModified": 1788914643,
+        "narHash": "sha256-4GuMPW90JSxXWDPUB9M+1m7fYbe3H0apOd86/zBQ2Kw=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "rev": "13616fff713a9f94055c66f15687ebdc17a335df",
         "type": "github"
       },
       "original": {
@@ -1299,11 +1299,11 @@
         "userborn": "userborn"
       },
       "locked": {
-        "lastModified": 1784579760,
-        "narHash": "sha256-7YKNfK0RQbUoYkjDI/EpTk76nDUiONJYuOxZnflx7tI=",
+        "lastModified": 1788643028,
+        "narHash": "sha256-llyR4NuuJLDS49y8j9zbGi5pzjSuuc6CB8ipPJlXfIk=",
         "owner": "numtide",
         "repo": "system-manager",
-        "rev": "48d47346e0c6ad05b6c869ea92649c47723d1cfc",
+        "rev": "41d9628959faa2d12f65057aeb6f566c4ccfbd3d",
         "type": "github"
       },
       "original": {
@@ -1377,11 +1377,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1785945821,
-        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {
@@ -1398,11 +1398,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785360170,
-        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {

--- a/modules/genebean/README.md
+++ b/modules/genebean/README.md
@@ -140,7 +140,7 @@ For apps that have separate Homebrew and Nix install paths (e.g. Ghostty).
 ```nix
 installViaHomebrew = lib.mkOption {
   type    = lib.types.bool;
-  default = pkgs.stdenv.isDarwin;
+  default = pkgs.stdenv.hostPlatform.isDarwin;
 };
 installViaNix = lib.mkOption {
   type    = lib.types.bool;

--- a/modules/genebean/home/programs/angry-ip-scanner.nix
+++ b/modules/genebean/home/programs/angry-ip-scanner.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Angry IP Scanner network scanner";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.angryipscanner ];
   };
 }

--- a/modules/genebean/home/programs/audacity.nix
+++ b/modules/genebean/home/programs/audacity.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Audacity audio editor";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.audacity ];
   };
 }

--- a/modules/genebean/home/programs/boinc.nix
+++ b/modules/genebean/home/programs/boinc.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "BOINC distributed computing client";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.boinc ];
   };
 }

--- a/modules/genebean/home/programs/claude-code.nix
+++ b/modules/genebean/home/programs/claude-code.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Claude Code AI coding assistant";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.claude-code ];
   };
 }

--- a/modules/genebean/home/programs/filezilla.nix
+++ b/modules/genebean/home/programs/filezilla.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "FileZilla FTP client";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.filezilla ];
   };
 }

--- a/modules/genebean/home/programs/ghostty.nix
+++ b/modules/genebean/home/programs/ghostty.nix
@@ -13,7 +13,7 @@ in
     enable = lib.mkEnableOption "Ghostty terminal";
     installViaHomebrew = lib.mkOption {
       type = lib.types.bool;
-      default = pkgs.stdenv.isDarwin;
+      default = pkgs.stdenv.hostPlatform.isDarwin;
     };
     installViaNix = lib.mkOption {
       type = lib.types.bool;
@@ -26,7 +26,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.file = lib.mkIf pkgs.stdenv.isDarwin {
+    home.file = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
       "Library/Application Support/com.mitchellh.ghostty/config".text = ''
         # Ghostty configuration is managed by home-manager.
         # Settings are in modules/genebean/home/programs/ghostty.nix in the dots repo.

--- a/modules/genebean/home/programs/gitkraken.nix
+++ b/modules/genebean/home/programs/gitkraken.nix
@@ -20,7 +20,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = lib.mkIf (pkgs.stdenv.isLinux && cfg.linuxInstallMethod == "nixpkgs") [
+    home.packages = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && cfg.linuxInstallMethod == "nixpkgs") [
       pkgs.gitkraken
     ];
 

--- a/modules/genebean/home/programs/handbrake.nix
+++ b/modules/genebean/home/programs/handbrake.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "HandBrake video transcoder";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.handbrake ];
   };
 }

--- a/modules/genebean/home/programs/hexchat.nix
+++ b/modules/genebean/home/programs/hexchat.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "HexChat IRC client";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     programs.hexchat.enable = true;
   };
 }

--- a/modules/genebean/home/programs/meld.nix
+++ b/modules/genebean/home/programs/meld.nix
@@ -19,7 +19,7 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = lib.mkIf (cfg.linuxInstallMethod == "nixpkgs") [
       pkgs.meld
     ];

--- a/modules/genebean/home/programs/mkvtoolnix.nix
+++ b/modules/genebean/home/programs/mkvtoolnix.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "MKVToolNix Matroska tools";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.mkvtoolnix ];
   };
 }

--- a/modules/genebean/home/programs/mqtt-explorer.nix
+++ b/modules/genebean/home/programs/mqtt-explorer.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "MQTT Explorer";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.mqtt-explorer ];
   };
 }

--- a/modules/genebean/home/programs/mumble.nix
+++ b/modules/genebean/home/programs/mumble.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Mumble VoIP client";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.mumble ];
   };
 }

--- a/modules/genebean/home/programs/nextcloud-client.nix
+++ b/modules/genebean/home/programs/nextcloud-client.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Nextcloud desktop client";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.nextcloud-client ];
   };
 }

--- a/modules/genebean/home/programs/obs.nix
+++ b/modules/genebean/home/programs/obs.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "OBS Studio";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.obs-studio ];
   };
 }

--- a/modules/genebean/home/programs/pidgin.nix
+++ b/modules/genebean/home/programs/pidgin.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Pidgin IM client";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     programs.pidgin.enable = true;
   };
 }

--- a/modules/genebean/home/programs/slack.nix
+++ b/modules/genebean/home/programs/slack.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Slack messaging";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.slack ];
   };
 }

--- a/modules/genebean/home/programs/tilix/default.nix
+++ b/modules/genebean/home/programs/tilix/default.nix
@@ -13,7 +13,7 @@ with lib.hm.gvariant;
     enable = lib.mkEnableOption "Tilix terminal emulator";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     dconf.settings = {
       "com/gexperts/Tilix/profiles/2b7c4080-0ddd-46c5-8f23-563fd3ba789d" = {
         background-color = "#272822";

--- a/modules/genebean/home/programs/transmission.nix
+++ b/modules/genebean/home/programs/transmission.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Transmission BitTorrent client";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [ pkgs.transmission_4-gtk ];
   };
 }

--- a/modules/genebean/home/programs/vlc.nix
+++ b/modules/genebean/home/programs/vlc.nix
@@ -22,7 +22,7 @@ in
     enable = lib.mkEnableOption "VLC media player with Blu-ray decoding support";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = [
       pkgs.libbdplus
       vlc-with-decoding

--- a/modules/genebean/home/programs/vscode.nix
+++ b/modules/genebean/home/programs/vscode.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Visual Studio Code";
   };
 
-  config = lib.mkIf (cfg.enable && !pkgs.stdenv.isDarwin) {
+  config = lib.mkIf (cfg.enable && !pkgs.stdenv.hostPlatform.isDarwin) {
     programs.vscode.enable = true;
   };
 }

--- a/modules/genebean/home/programs/waybar/default.nix
+++ b/modules/genebean/home/programs/waybar/default.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "Waybar status bar";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.file = {
       ".config/waybar/config".source = ./config;
       ".config/waybar/frappe.css".source =

--- a/modules/genebean/home/programs/wezterm/default.nix
+++ b/modules/genebean/home/programs/wezterm/default.nix
@@ -12,11 +12,11 @@ in
     enable = lib.mkEnableOption "WezTerm terminal";
     installViaHomebrew = lib.mkOption {
       type = lib.types.bool;
-      default = pkgs.stdenv.isDarwin;
+      default = pkgs.stdenv.hostPlatform.isDarwin;
     };
     installViaNix = lib.mkOption {
       type = lib.types.bool;
-      default = !pkgs.stdenv.isDarwin;
+      default = !pkgs.stdenv.hostPlatform.isDarwin;
     };
   };
 

--- a/modules/genebean/home/programs/xfce4-terminal/default.nix
+++ b/modules/genebean/home/programs/xfce4-terminal/default.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "xfce4-terminal";
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home = {
       packages = [ pkgs.xfce4-terminal ];
       file = {

--- a/modules/genebean/home/programs/zoom.nix
+++ b/modules/genebean/home/programs/zoom.nix
@@ -19,7 +19,7 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+  config = lib.mkIf (cfg.enable && pkgs.stdenv.hostPlatform.isLinux) {
     home.packages = lib.mkIf (cfg.linuxInstallMethod == "nixpkgs") [
       pkgs.zoom-us
     ];

--- a/modules/genebean/home/programs/zsh.nix
+++ b/modules/genebean/home/programs/zsh.nix
@@ -140,7 +140,7 @@ in
           ykey = "pkill -9 gpg-agent && zsh -ic 'ssh-add -L'; exec zsh";
         }
         # ─── Linux (all Linux) ────────────────────────────────────────────────
-        // lib.optionalAttrs pkgs.stdenv.isLinux {
+        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           pbcopy = "wl-copy";
         }
         # ─── NixOS ────────────────────────────────────────────────────────────

--- a/pkgs/nixdiff/default.nix
+++ b/pkgs/nixdiff/default.nix
@@ -6,5 +6,9 @@ pkgs.writeShellApplication {
     pkgs.jq
     pkgs.nvd
   ];
-  text = if pkgs.stdenv.isDarwin then builtins.readFile ./darwin.sh else builtins.readFile ./linux.sh;
+  text =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      builtins.readFile ./darwin.sh
+    else
+      builtins.readFile ./linux.sh;
 }


### PR DESCRIPTION
## Summary

- Ran `nix flake update` across all inputs
- Replaced deprecated `pkgs.stdenv.isLinux` / `pkgs.stdenv.isDarwin` with `pkgs.stdenv.hostPlatform.isLinux` / `pkgs.stdenv.hostPlatform.isDarwin` throughout genebean modules (nixpkgs 26.05 deprecation)
- Updated `genebean-neovim` input after fixing the same deprecation in genebean/neovim-flake#4 and a `nix-wrapper-modules` breaking change (`extraPackages` → `runtimePkgs`) in genebean/neovim-flake#5

## Test plan

- [x] `nixup` applied cleanly on rainbow-planet (system-manager + home-manager)
- [x] `nixnuc` dry-activate succeeded with no deprecation warnings
- [ ] Deploy to remaining hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017v7xSAMmCce1GQhnTx2Lmk