### PR TITLE
Add WordPress for Cub Scout Pack 138 on hetznix01

### DIFF
--- a/modules/hosts/nixos/hetznix01/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/default.nix
@@ -17,6 +17,7 @@ in
     ./monitoring.nix
     #./mosquitto.nix
     ./nginx.nix
+    ./wordpress.nix
   ];
 
   services = {

--- a/modules/hosts/nixos/hetznix01/post-install/wordpress.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/wordpress.nix
@@ -5,6 +5,20 @@ let
   # so we can symlink them into /etc/fail2ban/filter.d/ below.
   wpf2b = wpPlugins.wp-fail2ban;
 
+  # Infield theme — GPL v2, by Automattic. Not in nixpkgs; sourced from
+  # https://github.com/Automattic/themes (only the infield/ subdirectory is used).
+  infield-theme = pkgs.stdenv.mkDerivation {
+    pname = "infield";
+    version = "1.0.1";
+    src = pkgs.fetchFromGitHub {
+      owner = "Automattic";
+      repo = "themes";
+      rev = "a8cdadabc1132aae2eccfde8523d9cc67a940583";
+      hash = "sha256-FiRB/LQrTt6QhV5Sg3ltRK4diR9pBQS+Xl4Ng7Tn1jQ=";
+    };
+    installPhase = "mkdir -p $out; cp -r infield/. $out/";
+  };
+
   # wordpress-importer is not yet in nixpkgs — package it manually.
   # Needed once to import the WXR export from wordpress.com; remove after migration.
   wordpress-importer = pkgs.stdenv.mkDerivation rec {
@@ -156,6 +170,10 @@ in
         #   1. wp-fail2ban     — starts logging auth events to syslog immediately
         #   2. disable-xml-rpc — disables XML-RPC at the WordPress layer
         #   3. simple-login-captcha — adds math captcha to the login page
+        themes = {
+          inherit infield-theme;
+        };
+
         plugins = {
           inherit (wpPlugins) disable-xml-rpc;
           inherit (wpPlugins) simple-login-captcha;

--- a/modules/hosts/nixos/hetznix01/post-install/wordpress.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/wordpress.nix
@@ -4,6 +4,18 @@ let
   # wp-fail2ban ships its own fail2ban filter files — reference the store path
   # so we can symlink them into /etc/fail2ban/filter.d/ below.
   wpf2b = wpPlugins.wp-fail2ban;
+
+  # wordpress-importer is not yet in nixpkgs — package it manually.
+  # Needed once to import the WXR export from wordpress.com; remove after migration.
+  wordpress-importer = pkgs.stdenv.mkDerivation rec {
+    pname = "wordpress-importer";
+    version = "0.9.6";
+    src = pkgs.fetchzip {
+      url = "https://downloads.wordpress.org/plugin/${pname}.${version}.zip";
+      hash = "sha256-rc/Ut0HYmqTsP2Yc3tcqVRXU3zq7H9wf80SmGqQSYF4=";
+    };
+    installPhase = "mkdir -p $out; cp -R * $out/";
+  };
 in
 {
   # Symlink the fail2ban filter files that ship with the wp-fail2ban plugin into
@@ -145,6 +157,7 @@ in
           inherit (wpPlugins) disable-xml-rpc;
           inherit (wpPlugins) wp-fail2ban;
           inherit (wpPlugins) simple-login-captcha;
+          inherit wordpress-importer;
         };
 
         settings = {

--- a/modules/hosts/nixos/hetznix01/post-install/wordpress.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/wordpress.nix
@@ -1,0 +1,171 @@
+{ config, pkgs, ... }:
+let
+  wpPlugins = pkgs.wordpressPackages.plugins;
+  # wp-fail2ban ships its own fail2ban filter files — reference the store path
+  # so we can symlink them into /etc/fail2ban/filter.d/ below.
+  wpf2b = wpPlugins.wp-fail2ban;
+in
+{
+  # Symlink the fail2ban filter files that ship with the wp-fail2ban plugin into
+  # /etc/fail2ban/filter.d/ so fail2ban can reference them by name in the jails.
+  # The plugin must be activated in WP admin for these filters to see any events.
+  #
+  # Filter severity levels:
+  #   hard  — immediate/severe failures (unknown users, XML-RPC multicall, etc.)
+  #   soft  — recoverable failures (wrong password, etc.)
+  #   extra — informational events (comments, password resets)
+  environment.etc = {
+    "fail2ban/filter.d/wordpress-hard.conf".source = "${wpf2b}/filters.d/wordpress-hard.conf";
+    "fail2ban/filter.d/wordpress-soft.conf".source = "${wpf2b}/filters.d/wordpress-soft.conf";
+    "fail2ban/filter.d/wordpress-extra.conf".source = "${wpf2b}/filters.d/wordpress-extra.conf";
+  };
+
+  services = {
+    # Fail2ban jails for WordPress auth events.
+    # wp-fail2ban writes to syslog via openlog("wordpress", ...) which journald
+    # captures as SYSLOG_IDENTIFIER=wordpress — no log file path needed.
+    fail2ban.jails = {
+      # Hard failures get an immediate 24-hour ban (1 strike = you're out).
+      # Covers: unknown users, XML-RPC multicall, blocked users, etc.
+      "wordpress-hard" = ''
+        enabled      = true
+        filter       = wordpress-hard
+        backend      = systemd
+        journalmatch = SYSLOG_IDENTIFIER=wordpress
+        maxretry     = 1
+        findtime     = 3600
+        bantime      = 86400
+      '';
+
+      # Soft failures (wrong password, etc.) allow a small number of attempts
+      # before banning — accommodates legitimate users who mistype.
+      "wordpress-soft" = ''
+        enabled      = true
+        filter       = wordpress-soft
+        backend      = systemd
+        journalmatch = SYSLOG_IDENTIFIER=wordpress
+        maxretry     = 5
+        findtime     = 3600
+        bantime      = 3600
+      '';
+    };
+
+    # MariaDB — required by WordPress (it doesn't support PostgreSQL).
+    # Conservative settings keep memory low on this shared VPS.
+    mysql = {
+      enable = true;
+      package = pkgs.mariadb;
+      settings.mysqld = {
+        # Small buffer pool appropriate for a low-traffic Cub Scout site sharing
+        # a VPS with several other services.
+        innodb_buffer_pool_size = "64M";
+        max_connections = 25;
+      };
+    };
+
+    # Daily MariaDB backup matching the existing PostgreSQL backup schedule.
+    # Unlike services.postgresqlBackup there is no backupAll option — any future
+    # MariaDB-backed services must be added to this list explicitly.
+    mysqlBackup = {
+      enable = true;
+      databases = [ "wordpress_138cubpack" ];
+      calendar = "*-*-* 23:00:00";
+    };
+
+    nginx.virtualHosts = {
+      # Extend the nginx virtual host that the WordPress module creates.
+      #
+      # SSL/TLS NOTE: cert issuance uses the Gandi DNS challenge (lets-encrypt.nix).
+      # The cert cannot issue until 138cubpack.com is transferred to Gandi nameservers.
+      # Until then nginx uses a self-signed placeholder and HTTPS shows a browser
+      # warning — this is expected.  Transfer the domain to Gandi first, then point
+      # the A/AAAA records at this host; the cert will issue automatically.
+      "138cubpack.com" = {
+        serverAliases = [ "www.138cubpack.com" ];
+        enableACME = true;
+        acmeRoot = null; # DNS challenge via Gandi — no webroot needed
+        forceSSL = true;
+        locations."= /xmlrpc.php" = {
+          # Defense-in-depth: block xmlrpc.php at the nginx layer before PHP runs,
+          # saving CPU.  The disable-xml-rpc plugin also disables it at the WP layer.
+          # Note: requests blocked here will NOT be logged by wp-fail2ban (PHP never
+          # runs), but the attacker still gets a 403 so the attack fails.
+          return = "403";
+        };
+      };
+
+      # Development vhost — available immediately because technicalissues.us is
+      # already at Gandi, so the ACME cert issues without waiting for the
+      # 138cubpack.com domain transfer.  Use this URL to set up and test WordPress
+      # before cutting over the real domain.
+      #
+      # NOTE: WordPress will store 138cubpack.technicalissues.us as the site URL
+      # during initial setup.  After real DNS is live, change Site URL + Home URL
+      # in WP Admin → Settings → General to https://138cubpack.com.
+      "138cubpack.technicalissues.us" = {
+        enableACME = true;
+        acmeRoot = null;
+        forceSSL = true;
+        # Mirror the root, extraConfig (contains `index index.php;`), and locations
+        # from the primary vhost so the two stay in sync automatically.
+        root = config.services.nginx.virtualHosts."138cubpack.com".root;
+        extraConfig = config.services.nginx.virtualHosts."138cubpack.com".extraConfig;
+        locations = config.services.nginx.virtualHosts."138cubpack.com".locations;
+      };
+    };
+
+    restic.backups.daily.paths = [
+      "/var/backup/mysql"
+      "/var/lib/wordpress/138cubpack.com/uploads"
+    ];
+
+    # WordPress site for Cub Scout Pack 138 (138cubpack.com).
+    # The NixOS module handles PHP-FPM pool creation and nginx vhost wiring;
+    # we extend both below.
+    wordpress = {
+      webserver = "nginx";
+      sites."138cubpack.com" = {
+        database = {
+          # Unix socket auth: the PHP-FPM pool runs as the "wordpress" system user
+          # and MariaDB authenticates by matching that Unix user — no password needed.
+          createLocally = true;
+          name = "wordpress_138cubpack";
+          user = "wordpress";
+        };
+
+        # Persistent uploads directory outside the read-only Nix store.
+        uploadsDir = "/var/lib/wordpress/138cubpack.com/uploads";
+
+        # Plugins installed by Nix (copied into wp-content/plugins at deploy time).
+        # IMPORTANT: activate them in WP admin after first deploy, in this order:
+        #   1. wp-fail2ban     — starts logging auth events to syslog immediately
+        #   2. disable-xml-rpc — disables XML-RPC at the WordPress layer
+        #   3. simple-login-captcha — adds math captcha to the login page
+        plugins = {
+          inherit (wpPlugins) disable-xml-rpc;
+          inherit (wpPlugins) wp-fail2ban;
+          inherit (wpPlugins) simple-login-captcha;
+        };
+
+        settings = {
+          # Force WP admin to require HTTPS even when accessed over HTTP.
+          FORCE_SSL_ADMIN = true;
+        };
+
+        extraConfig = ''
+          # Tell WordPress it is behind an HTTPS-terminating reverse proxy (nginx).
+          # Without this, WordPress generates http:// URLs for admin redirects.
+          $_SERVER['HTTPS'] = 'on';
+        '';
+
+        # Spawn PHP workers only on demand; reclaim memory when idle.
+        # 4 workers is plenty for a low-traffic pack site.
+        poolConfig = {
+          "pm" = "ondemand";
+          "pm.max_children" = 4;
+          "pm.process_idle_timeout" = "10s";
+        };
+      };
+    };
+  };
+}

--- a/modules/hosts/nixos/hetznix01/post-install/wordpress.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/wordpress.nix
@@ -97,6 +97,9 @@ in
         enableACME = true;
         acmeRoot = null; # DNS challenge via Gandi — no webroot needed
         forceSSL = true;
+        extraConfig = ''
+          client_max_body_size 50M;
+        '';
         locations."= /xmlrpc.php" = {
           # Defense-in-depth: block xmlrpc.php at the nginx layer before PHP runs,
           # saving CPU.  The disable-xml-rpc plugin also disables it at the WP layer.
@@ -155,8 +158,9 @@ in
         #   3. simple-login-captcha — adds math captcha to the login page
         plugins = {
           inherit (wpPlugins) disable-xml-rpc;
-          inherit (wpPlugins) wp-fail2ban;
           inherit (wpPlugins) simple-login-captcha;
+          inherit (wpPlugins) webp-converter-for-media;
+          inherit (wpPlugins) wp-fail2ban;
           inherit wordpress-importer;
         };
 
@@ -177,6 +181,8 @@ in
           "pm" = "ondemand";
           "pm.max_children" = 4;
           "pm.process_idle_timeout" = "10s";
+          "php_admin_value[upload_max_filesize]" = "50M";
+          "php_admin_value[post_max_size]" = "50M";
         };
       };
     };


### PR DESCRIPTION
## Summary

- Add `services.wordpress` on hetznix01 for Cub Scout Pack 138 (`138cubpack.com`)
- MariaDB + `mysqlBackup` (mirrors existing PostgreSQL backup pattern)
- Nginx vhosts for both `138cubpack.com` (primary) and `138cubpack.technicalissues.us` (dev, usable before domain transfer)
- Dev vhost references primary vhost's `root`, `extraConfig`, and `locations` to stay in sync automatically
- fail2ban jails wired to `wp-fail2ban` plugin's own filter files via `environment.etc` symlinks
- Nix-managed plugins: `disable-xml-rpc`, `wp-fail2ban`, `simple-login-captcha`, `wordpress-importer`
- `wordpress-importer` packaged manually (not yet in nixpkgs) for one-time WXR migration from wordpress.com; remove after import is complete
- Restic backup paths for MySQL dumps and uploads directory

## Migration steps (after merging / deploying)

- [x] Rebuild and switch on hetznix01
- [x] Activate `wordpress-importer` in WP Admin → Plugins
- [x] Export content from wordpress.com: Tools → Export → All content
- [x] Import via WP Admin → Tools → Import → WordPress (check "Download and import file attachments")
- [ ] Transfer `138cubpack.com` domain from WordPress.com to Gandi
- [ ] Point A/AAAA records at hetznix01 (cert auto-issues via Gandi DNS challenge)
- [ ] Update Site URL + Home URL in WP Admin → Settings → General to `https://138cubpack.com`
- [ ] Remove `wordpress-importer` derivation and plugin entry, redeploy
- [ ] Cancel WordPress.com Personal plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)