### PR TITLE
Decommission pack1828.org

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1124,11 +1124,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782355444,
-        "narHash": "sha256-k0Lx2KkxNlL8CKuJF/tJpszRCG50IscHM2tiWQBWDAg=",
+        "lastModified": 1789129563,
+        "narHash": "sha256-Os3bV520GDJdFASsV5OZdqWal6qDXcEe/7YkbK9xHyM=",
         "owner": "genebean",
         "repo": "private-flake",
-        "rev": "19444ba02f1bf82d59c0ad342ef8159975beda4d",
+        "rev": "382ba0647ef6bb8fe76a8b92cca52f348081de88",
         "type": "github"
       },
       "original": {

--- a/modules/hosts/nixos/hetznix01/hardware-configuration.nix
+++ b/modules/hosts/nixos/hetznix01/hardware-configuration.nix
@@ -24,15 +24,5 @@
     extraModulePackages = [ ];
   };
 
-  fileSystems."pack1828" = {
-    device = "/dev/disk/by-id/scsi-0HC_Volume_102600992";
-    fsType = "ext4";
-    options = [
-      "discard"
-      "nofail"
-      "defaults"
-    ];
-  };
-
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 }

--- a/modules/hosts/nixos/hetznix01/post-install/default.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/default.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   username,
   ...
@@ -31,32 +30,6 @@ in
       query_thread_log.ttl = "event_date + INTERVAL 30 DAY DELETE";
       text_log.ttl = "event_date + INTERVAL 14 DAY DELETE";
     };
-    collabora-online = {
-      enable = true;
-      inherit (config.genebean.ports.collabora) port;
-      settings = {
-        # Rely on reverse proxy for SSL
-        ssl = {
-          enable = false;
-          termination = true;
-        };
-
-        # Listen on loopback interface only, and accept requests from ::1
-        net = {
-          listen = "loopback";
-          post_allow.host = [ "::1" ];
-        };
-
-        # Restrict loading documents from WOPI Host nextcloud.example.com
-        storage.wopi = {
-          "@allow" = true;
-          host = [ "https://cloud.pack1828.org" ];
-        };
-
-        # Set FQDN of server
-        server_name = "collabora.pack1828.org";
-      };
-    };
     dawarich = {
       enable = true;
       configureNginx = true;
@@ -71,55 +44,6 @@ in
       smtp = {
         fromAddress = "location@hetznix01.technicalissues.us";
         host = "127.0.0.1";
-      };
-    };
-    nextcloud = {
-      enable = true;
-      hostName = "cloud.pack1828.org";
-      package = pkgs.nextcloud33; # Need to manually increment with every major upgrade.
-      appstoreEnable = true;
-      autoUpdateApps.enable = true;
-      config = {
-        adminuser = username;
-        adminpassFile = config.sops.secrets.nextcloud_admin_pass.path;
-        dbtype = "pgsql";
-      };
-      configureRedis = true;
-      database.createLocally = true;
-      extraApps = with config.services.nextcloud.package.packages.apps; {
-        # List of apps we want to install and are already packaged in
-        # https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/nextcloud/packages/nextcloud-apps.json
-        inherit
-          richdocuments # Collabora Online for Nextcloud - https://apps.nextcloud.com/apps/richdocuments
-          ;
-      };
-      extraAppsEnable = true;
-      home = "/pack1828/nextcloud";
-      https = true;
-      maxUploadSize = "3G"; # Increase the PHP maximum file upload size
-      phpOptions."opcache.interned_strings_buffer" = "16"; # Suggested by Nextcloud's health check.
-      settings = {
-        default_phone_region = "US";
-        # https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#enabledpreviewproviders
-        enabledPreviewProviders = [
-          "OC\\Preview\\BMP"
-          "OC\\Preview\\GIF"
-          "OC\\Preview\\JPEG"
-          "OC\\Preview\\Krita"
-          "OC\\Preview\\MarkDown"
-          "OC\\Preview\\MP3"
-          "OC\\Preview\\OpenDocument"
-          "OC\\Preview\\PNG"
-          "OC\\Preview\\TXT"
-          "OC\\Preview\\XBitmap"
-
-          "OC\\Preview\\HEIC"
-          "OC\\Preview\\Movie"
-        ];
-        log_type = "file";
-        maintenance_window_start = 5;
-        overwriteProtocol = "https";
-        "profile.enabled" = true;
       };
     };
     plausible = {
@@ -168,7 +92,6 @@ in
       };
       matrix_homeserver_signing_key.owner = config.users.users.matrix-synapse.name;
       mqtt_recorder_pass.restartUnits = [ "mosquitto.service" ];
-      nextcloud_admin_pass.owner = config.users.users.nextcloud.name;
       plausible_admin_pass.owner = config.users.users.nginx.name;
       plausible_secret_key_base.owner = config.users.users.nginx.name;
     };
@@ -191,36 +114,6 @@ in
         '';
       };
 
-      nextcloud-config-collabora =
-        let
-          inherit (config.services.nextcloud) occ;
-
-          wopi_url = "http://[::1]:${toString config.services.collabora-online.port}";
-          public_wopi_url = "https://collabora.pack1828.org";
-          wopi_allowlist = lib.concatStringsSep "," [
-            "127.0.0.1"
-            "::1"
-            "5.161.244.95"
-            "2a01:4ff:f0:977c::1"
-          ];
-        in
-        {
-          wantedBy = [ "multi-user.target" ];
-          after = [
-            "nextcloud-setup.service"
-            "coolwsd.service"
-          ];
-          requires = [ "coolwsd.service" ];
-          script = ''
-            ${occ}/bin/nextcloud-occ config:app:set richdocuments wopi_url --value ${lib.escapeShellArg wopi_url}
-            ${occ}/bin/nextcloud-occ config:app:set richdocuments public_wopi_url --value ${lib.escapeShellArg public_wopi_url}
-            ${occ}/bin/nextcloud-occ config:app:set richdocuments wopi_allowlist --value ${lib.escapeShellArg wopi_allowlist}
-            ${occ}/bin/nextcloud-occ richdocuments:setup
-          '';
-          serviceConfig = {
-            Type = "oneshot";
-          };
-        };
     };
 
     timers.clickhouse-drop-orphaned-logs = {

--- a/modules/hosts/nixos/hetznix01/post-install/nginx.nix
+++ b/modules/hosts/nixos/hetznix01/post-install/nginx.nix
@@ -107,20 +107,6 @@ in
           };
         };
       };
-      "cloud.pack1828.org" = {
-        enableACME = true;
-        acmeRoot = null;
-        forceSSL = true;
-      };
-      "collabora.pack1828.org" = {
-        enableACME = true;
-        acmeRoot = null;
-        forceSSL = true;
-        locations."/" = {
-          proxyPass = "http://[::1]:${toString config.services.collabora-online.port}";
-          proxyWebsockets = true; # collabora uses websockets
-        };
-      };
       "location.${domain}" = {
         enableACME = true;
         acmeRoot = null;
@@ -190,14 +176,6 @@ in
         acmeRoot = null;
         forceSSL = true;
         locations."/".return = "301 https://beanbag.technicalissues.us";
-      };
-      "pack1828.org" = {
-        enableACME = true;
-        acmeRoot = null;
-        forceSSL = true;
-        locations."/" = {
-          return = "307 https://cloud.pack1828.org";
-        };
       };
       "stats.${domain}" = {
         enableACME = true;


### PR DESCRIPTION
## Summary

- Remove Nextcloud, Collabora Online, and associated nginx vhosts (`cloud.pack1828.org`, `collabora.pack1828.org`, `pack1828.org` redirect)
- Remove `pack1828` Hetzner supplemental volume from fstab — volume was unmounted automatically on deploy and has since been detached and deleted in the Hetzner console
- Update `private-flake` input to pick up removal of `pack1828.org`/`indianspringsbsa.org` email domains and sops secrets (genebean/private-flake#10)

## Test plan
- [x] Dry-run deploy validated clean output
- [x] Real deploy confirmed — all pack1828 units stopped, users/groups removed, secrets wiped, nginx restarted cleanly
- [x] Hetzner volume detached and deleted

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)